### PR TITLE
✨ Feature / Mix security.check_release task

### DIFF
--- a/lib/mix/tasks/security.check_release.ex
+++ b/lib/mix/tasks/security.check_release.ex
@@ -1,0 +1,87 @@
+defmodule Mix.Tasks.Security.CheckRelease do
+  @shortdoc "Run pre-release security checks for ExSaml"
+  @moduledoc """
+  Scans the codebase for known unsafe patterns specific to SAML/XML processing.
+
+  Checks:
+
+    * `xmerl_scan.string` calls without `allow_entities: false` (XXE)
+    * `signature_props` without a catch-all clause (crash on unknown algorithm)
+
+  ## Usage
+
+      mix security.check_release
+  """
+
+  use Mix.Task
+
+  @lib_path "lib"
+  @self_path "lib/mix/tasks/security.check_release.ex"
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.shell().info("Running ExSaml pre-release security checks...\n")
+
+    findings =
+      source_files()
+      |> Enum.flat_map(&check_xxe/1)
+
+    algo_findings = check_signature_props_catchall()
+
+    all = findings ++ algo_findings
+
+    case all do
+      [] ->
+        Mix.shell().info("All checks passed.")
+
+      _ ->
+        Enum.each(all, fn {file, line, message} ->
+          Mix.shell().error("  #{file}:#{line} — #{message}")
+        end)
+
+        Mix.raise("Security check failed: #{length(all)} issue(s) found.")
+    end
+  end
+
+  defp source_files do
+    @lib_path
+    |> Path.join("**/*.ex")
+    |> Path.wildcard()
+    |> Enum.reject(&(&1 == @self_path))
+  end
+
+  defp check_xxe(path) do
+    content = File.read!(path)
+    lines = String.split(content, "\n")
+
+    lines
+    |> Enum.with_index(1)
+    |> Enum.filter(fn {line, _} -> String.contains?(line, ":xmerl_scan.string") end)
+    |> Enum.reject(fn {_line, line_number} ->
+      # Check next 3 lines for allow_entities: false (handles multiline formatting)
+      lines
+      |> Enum.slice(line_number - 1, 4)
+      |> Enum.join("\n")
+      |> String.contains?("allow_entities: false")
+    end)
+    |> Enum.map(fn {_line, line_number} ->
+      {path, line_number, "xmerl_scan.string without allow_entities: false (XXE risk)"}
+    end)
+  end
+
+  defp check_signature_props_catchall do
+    dsig_path = Path.join(@lib_path, "ex_saml/core/xml/dsig.ex")
+
+    if File.exists?(dsig_path) do
+      content = File.read!(dsig_path)
+
+      if Regex.match?(~r/def signature_props\(_/, content) do
+        []
+      else
+        [{dsig_path, 0, "signature_props has no catch-all clause (crash on unknown algorithm)"}]
+      end
+    else
+      []
+    end
+  end
+end

--- a/lib/mix/tasks/security.check_release.ex
+++ b/lib/mix/tasks/security.check_release.ex
@@ -3,10 +3,21 @@ defmodule Mix.Tasks.Security.CheckRelease do
   @moduledoc """
   Scans the codebase for known unsafe patterns specific to SAML/XML processing.
 
-  Checks:
+  Errors block the release. Warnings are acknowledged risks that require review.
 
-    * `xmerl_scan.string` calls without `allow_entities: false` (XXE)
-    * `signature_props` without a catch-all clause (crash on unknown algorithm)
+  ### Errors (block release)
+
+    * XXE — `xmerl_scan.string` calls without `allow_entities: false`
+    * XXE — `xmerl_scan.string` calls without `namespace_conformant: true`
+    * Algorithm — `signature_props` without a catch-all clause
+    * Algorithm — signing with `:rsa_sha1` (weak hash)
+
+  ### Warnings (review before release)
+
+    * Certificate — `check_fingerprints(_, :any)` accepts any cert
+    * Open redirect — RelayState used in redirect without URL validation
+    * CSRF — unsolicited SAML responses accepted without target URL restriction
+    * Comment injection — NameID/attribute extraction without comment stripping
 
   ## Usage
 
@@ -22,26 +33,56 @@ defmodule Mix.Tasks.Security.CheckRelease do
   def run(_args) do
     Mix.shell().info("Running ExSaml pre-release security checks...\n")
 
-    findings =
-      source_files()
-      |> Enum.flat_map(&check_xxe/1)
+    errors =
+      List.flatten([
+        run_file_checks(),
+        check_signature_props_catchall(),
+        check_sign_with_sha1()
+      ])
 
-    algo_findings = check_signature_props_catchall()
+    warnings =
+      List.flatten([
+        check_fingerprints_any(),
+        check_relay_state_open_redirect(),
+        check_unsolicited_response_target(),
+        check_comment_injection()
+      ])
 
-    all = findings ++ algo_findings
+    print_results("error", errors)
+    print_results("warning", warnings)
+    print_summary(errors, warnings)
 
-    case all do
-      [] ->
-        Mix.shell().info("All checks passed.")
-
-      _ ->
-        Enum.each(all, fn {file, line, message} ->
-          Mix.shell().error("  #{file}:#{line} — #{message}")
-        end)
-
-        Mix.raise("Security check failed: #{length(all)} issue(s) found.")
+    if errors != [] do
+      Mix.raise("Security check failed: #{length(errors)} error(s) found.")
     end
   end
+
+  defp print_results(_label, []), do: :ok
+
+  defp print_results(label, findings) do
+    Enum.each(findings, fn {file, line, message} ->
+      Mix.shell().error("  [#{label}] #{file}:#{line} — #{message}")
+    end)
+  end
+
+  defp print_summary(errors, warnings) do
+    Mix.shell().info("")
+
+    case {errors, warnings} do
+      {[], []} ->
+        Mix.shell().info("All checks passed.")
+
+      {[], _} ->
+        Mix.shell().info("No errors. #{length(warnings)} warning(s) — review before release.")
+
+      _ ->
+        :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
 
   defp source_files do
     @lib_path
@@ -50,24 +91,54 @@ defmodule Mix.Tasks.Security.CheckRelease do
     |> Enum.reject(&(&1 == @self_path))
   end
 
+  defp read_lines(path), do: path |> File.read!() |> String.split("\n")
+
+  defp window(lines, line_number, size) do
+    lines |> Enum.slice(line_number - 1, size) |> Enum.join("\n")
+  end
+
+  # ---------------------------------------------------------------------------
+  # ERRORS — Per-file checks (XXE + namespace_conformant)
+  # ---------------------------------------------------------------------------
+
+  defp run_file_checks do
+    source_files()
+    |> Enum.flat_map(fn path ->
+      check_xxe(path) ++ check_namespace_conformant(path)
+    end)
+  end
+
   defp check_xxe(path) do
-    content = File.read!(path)
-    lines = String.split(content, "\n")
+    lines = read_lines(path)
 
     lines
     |> Enum.with_index(1)
     |> Enum.filter(fn {line, _} -> String.contains?(line, ":xmerl_scan.string") end)
-    |> Enum.reject(fn {_line, line_number} ->
-      # Check next 3 lines for allow_entities: false (handles multiline formatting)
-      lines
-      |> Enum.slice(line_number - 1, 4)
-      |> Enum.join("\n")
-      |> String.contains?("allow_entities: false")
+    |> Enum.reject(fn {_line, n} ->
+      String.contains?(window(lines, n, 4), "allow_entities: false")
     end)
-    |> Enum.map(fn {_line, line_number} ->
-      {path, line_number, "xmerl_scan.string without allow_entities: false (XXE risk)"}
+    |> Enum.map(fn {_line, n} ->
+      {path, n, "xmerl_scan.string without allow_entities: false (XXE risk)"}
     end)
   end
+
+  defp check_namespace_conformant(path) do
+    lines = read_lines(path)
+
+    lines
+    |> Enum.with_index(1)
+    |> Enum.filter(fn {line, _} -> String.contains?(line, ":xmerl_scan.string") end)
+    |> Enum.reject(fn {_line, n} ->
+      String.contains?(window(lines, n, 4), "namespace_conformant: true")
+    end)
+    |> Enum.map(fn {_line, n} ->
+      {path, n, "xmerl_scan.string without namespace_conformant: true (namespace confusion risk)"}
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # ERRORS — Algorithm checks
+  # ---------------------------------------------------------------------------
 
   defp check_signature_props_catchall do
     dsig_path = Path.join(@lib_path, "ex_saml/core/xml/dsig.ex")
@@ -80,6 +151,147 @@ defmodule Mix.Tasks.Security.CheckRelease do
       else
         [{dsig_path, 0, "signature_props has no catch-all clause (crash on unknown algorithm)"}]
       end
+    else
+      []
+    end
+  end
+
+  defp check_sign_with_sha1 do
+    dsig_path = Path.join(@lib_path, "ex_saml/core/xml/dsig.ex")
+
+    if File.exists?(dsig_path) do
+      lines = read_lines(dsig_path)
+
+      lines
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _} ->
+        Regex.match?(~r/Dsig\.sign\(.*:rsa_sha1/, line) ||
+          Regex.match?(~r/sign\(.*xmldsig#rsa-sha1/, line)
+      end)
+      |> Enum.map(fn {_line, n} ->
+        {dsig_path, n, "signing with RSA-SHA1 (weak algorithm, use RSA-SHA256+)"}
+      end)
+    else
+      []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # WARNINGS — Certificate validation
+  # ---------------------------------------------------------------------------
+
+  defp check_fingerprints_any do
+    dsig_path = Path.join(@lib_path, "ex_saml/core/xml/dsig.ex")
+
+    if File.exists?(dsig_path) do
+      lines = read_lines(dsig_path)
+
+      lines
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _} ->
+        Regex.match?(~r/check_fingerprints\(.*,\s*:any\)/, line)
+      end)
+      |> Enum.map(fn {_line, n} ->
+        {dsig_path, n,
+         "check_fingerprints(_, :any) accepts any certificate " <>
+           "(ensure this is never reachable with production config)"}
+      end)
+    else
+      []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # WARNINGS — Open redirect via RelayState
+  # ---------------------------------------------------------------------------
+
+  defp check_relay_state_open_redirect do
+    handler_path = Path.join(@lib_path, "ex_saml/sp_handler.ex")
+
+    if File.exists?(handler_path) do
+      lines = read_lines(handler_path)
+
+      lines
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _} ->
+        Regex.match?(~r/redirect\(.*start-from:/, line)
+      end)
+      |> Enum.map(fn {_line, n} ->
+        {handler_path, n,
+         "RelayState-derived URL used in redirect — verify URL is validated " <>
+           "against allowed_target_urls or a whitelist"}
+      end)
+    else
+      []
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # WARNINGS — Unsolicited SAML response (IdP-initiated) target URL restriction
+  # ---------------------------------------------------------------------------
+
+  defp check_unsolicited_response_target do
+    handler_path = Path.join(@lib_path, "ex_saml/sp_handler.ex")
+
+    if File.exists?(handler_path) do
+      content = File.read!(handler_path)
+      lines = read_lines(handler_path)
+
+      has_target_url_check =
+        Regex.match?(~r/allowed_target_urls.*relay_state/, content)
+
+      if has_target_url_check do
+        []
+      else
+        find_unsolicited_handler_lines(lines, handler_path)
+      end
+    else
+      []
+    end
+  end
+
+  defp find_unsolicited_handler_lines(lines, handler_path) do
+    lines
+    |> Enum.with_index(1)
+    |> Enum.filter(fn {line, _} ->
+      String.contains?(line, "in_response_to: \"\"") &&
+        String.contains?(line, "auth_target_url")
+    end)
+    |> Enum.map(fn {_line, n} ->
+      {handler_path, n,
+       "IdP-initiated flow accepts relay_state as redirect target " <>
+         "without allowed_target_urls check"}
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # WARNINGS — Comment injection in NameID / attributes
+  # ---------------------------------------------------------------------------
+
+  defp check_comment_injection do
+    saml_path = Path.join(@lib_path, "ex_saml/core/saml.ex")
+
+    if File.exists?(saml_path) do
+      content = File.read!(saml_path)
+      lines = read_lines(saml_path)
+
+      has_comment_filter =
+        Regex.match?(~r/xmlComment|strip_comment|reject_comment/, content)
+
+      lines
+      |> Enum.with_index(1)
+      |> Enum.filter(fn {line, _} ->
+        Regex.match?(~r/xmlText\(.*:value\)/, line) && !has_comment_filter
+      end)
+      |> Enum.reject(fn {_line, n} ->
+        w = window(lines, max(n - 10, 1), 20)
+        String.contains?(w, "def to_xml") || String.contains?(w, "# XML generation")
+      end)
+      |> Enum.map(fn {_line, n} ->
+        {saml_path, n,
+         "xmlText value extracted without explicit XML comment filtering " <>
+           "(potential comment injection in NameID/attributes)"}
+      end)
     else
       []
     end


### PR DESCRIPTION
## Summary

- Add `mix security.check_release` Mix task for pre-release SAML/XML security scanning
- **Errors** (block release): XXE, namespace confusion, missing algorithm catch-all, SHA-1 signing
- **Warnings** (review before release): `:any` fingerprints, open redirect via RelayState, unsolicited response target, comment injection

## Test plan

- [x] 125 existing tests pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo --strict` — no issues
- [x] `mix security.check_release` — 0 errors, 5 known warnings