### PR TITLE
📝 Docs / Drop autolink to hidden TableOwner module in start_ets/0

### DIFF
--- a/lib/ex_saml/core/util.ex
+++ b/lib/ex_saml/core/util.ex
@@ -497,7 +497,7 @@ defmodule ExSaml.Core.Util do
   @doc """
   No-op kept for backwards compatibility.
 
-  ETS tables are managed by `ExSaml.Core.TableOwner`. This function verifies
+  ETS tables are managed by an internal supervisor. This function verifies
   that the expected tables exist and returns `:ok`.
   """
   @spec start_ets() :: :ok


### PR DESCRIPTION
## Summary

- Silences an ExDoc build warning emitted on every \`mix docs\` run:

```elixir
warning: documentation references module \"ExSaml.Core.TableOwner\" but it is hidden
  │
500 │   ETS tables are managed by \`ExSaml.Core.TableOwner\`. This function verifies
  │
  └─ (ex_saml) lib/ex_saml/core/util.ex:500: ExSaml.Core.Util.start_ets/0
```

- Root cause: `ExSaml.Core.TableOwner` is an internal supervisor with `@moduledoc false`. The public docstring of `ExSaml.Core.Util.start_ets/0` back-quoted it, so ExDoc tried to autolink to a module it intentionally won't render.
- Fix: rephrase the reference to plain prose. Reader still understands the contract (tables are owned elsewhere; this is a no-op kept for backwards-compat), but ExDoc no longer attempts to cross-link a hidden module.

## Test plan

- [x] `mix docs` — no warnings on `util.ex:500` anymore.
- [x] `mix test` — 199 tests, 0 failures.
- [x] Visual check: rendered docstring still conveys "tables are managed elsewhere".