### PR TITLE
🐛 Fix / Prevent nil target URL crashing redirect in SAML error path

### DIFF
--- a/lib/ex_saml/sp_handler.ex
+++ b/lib/ex_saml/sp_handler.ex
@@ -296,9 +296,15 @@ defmodule ExSaml.SPHandler do
     #     conn |> send_resp(500, "request_failed")
   end
 
-  @doc "Returns the target URL from session or relay state cache."
+  @doc """
+  Returns the target URL from session or relay state cache, falling back
+  to `target_url/0` (`Application.get_env(:ex_saml, :fallback_target_url, "/")`)
+  when neither is set. Never returns `nil` — callers can safely pass the
+  result to `Plug.Conn.put_resp_header/3`.
+  """
   def target_url(conn, relay_state) do
-    get_session(conn, "target_url") || RelayStateCache.get(relay_state)[:target_url]
+    get_session(conn, "target_url") || RelayStateCache.get(relay_state)[:target_url] ||
+      target_url()
   end
 
   @doc "Returns the fallback target URL from application config (defaults to `\"/\"`)."

--- a/test/ex_saml/sp_handler_test.exs
+++ b/test/ex_saml/sp_handler_test.exs
@@ -1,0 +1,89 @@
+defmodule ExSaml.SPHandlerTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias ExSaml.SPHandler
+
+  # Minimal in-process stub for the cache configured via
+  # `config :ex_saml, cache: …`. The real cache is a Nebulex backend, but for
+  # unit-testing `target_url/2` we only need `get/1`. The returned value is
+  # read from the process dictionary so each test can drive its own scenario.
+  defmodule StubRelayCache do
+    def get(_key), do: Process.get(:stub_relay_cache_value)
+    def put(_key, _value, _opts), do: :ok
+    def delete(_key), do: :ok
+    def take(_key), do: nil
+    def ttl(_key), do: nil
+  end
+
+  setup do
+    previous_cache = Application.get_env(:ex_saml, :cache)
+    previous_fallback = Application.get_env(:ex_saml, :fallback_target_url)
+    Application.put_env(:ex_saml, :cache, StubRelayCache)
+
+    on_exit(fn ->
+      Process.delete(:stub_relay_cache_value)
+
+      if previous_cache do
+        Application.put_env(:ex_saml, :cache, previous_cache)
+      else
+        Application.delete_env(:ex_saml, :cache)
+      end
+
+      if previous_fallback do
+        Application.put_env(:ex_saml, :fallback_target_url, previous_fallback)
+      else
+        Application.delete_env(:ex_saml, :fallback_target_url)
+      end
+    end)
+
+    opts =
+      Plug.Session.init(
+        store: :cookie,
+        key: "_ex_saml_sp_handler_test_session",
+        encryption_salt: "salty enc",
+        signing_salt: "salty signing",
+        key_length: 64
+      )
+
+    conn =
+      conn(:get, "/")
+      |> Plug.Session.call(opts)
+      |> fetch_session()
+
+    {:ok, conn: conn}
+  end
+
+  describe "target_url/2" do
+    test "returns the session target_url when set", %{conn: conn} do
+      Process.put(:stub_relay_cache_value, %{target_url: "/from-cache"})
+      conn = put_session(conn, "target_url", "/from-session")
+
+      assert SPHandler.target_url(conn, "rls") == "/from-session"
+    end
+
+    test "returns the cached target_url when the session is empty", %{conn: conn} do
+      Process.put(:stub_relay_cache_value, %{target_url: "/from-cache"})
+
+      assert SPHandler.target_url(conn, "rls") == "/from-cache"
+    end
+
+    # Regression for issue #25: SAML error path crashed `redirect/3` because
+    # `target_url/2` returned `nil` when both stores were empty, and
+    # `Plug.Conn.put_resp_header/3` rejects a `nil` header value.
+    test "falls back to the configured default when session and cache are empty", %{conn: conn} do
+      Process.put(:stub_relay_cache_value, nil)
+
+      assert SPHandler.target_url(conn, "rls") == "/"
+      refute is_nil(SPHandler.target_url(conn, "rls"))
+    end
+
+    test "uses :fallback_target_url from app config when both stores are empty", %{conn: conn} do
+      Application.put_env(:ex_saml, :fallback_target_url, "/sign-in")
+      Process.put(:stub_relay_cache_value, nil)
+
+      assert SPHandler.target_url(conn, "rls") == "/sign-in"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `SPHandler.target_url/2` could return `nil` when neither the Plug session nor `RelayStateCache` carried a `target_url`. That `nil` reached `RouterUtil.redirect/3` and crashed `Plug.Conn.put_resp_header("location", nil)` with `FunctionClauseError`, surfacing as a 500 on `POST /sp/*glob/consume/:idp_id`.
- Fix: `target_url/2` now chains to the existing 0-arity `target_url/0` fallback (`Application.get_env(:ex_saml, :fallback_target_url, "/")`), guaranteeing a non-nil return for every caller — not just `redirect_with_error/3`.
- Aligns with the same `… || "/"` pattern already used in `auth_target_url/3` (`lib/ex_saml/sp_handler.ex`).
- No new config introduced; no defensive guard added to `RouterUtil.redirect/3` — root cause is fixed instead of masked.

## Why this clause

The other error branch — `redirect_with_error(conn, _, :invalid_target_url)` — was already safe because it uses the 0-arity `target_url/0`. Only the generic-error branch called the 2-arity variant, which is where the nil could leak through.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix credo --strict`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` — 203 tests, 0 failures
- [x] New regression test `test/ex_saml/sp_handler_test.exs` covering:
  - session value takes precedence
  - cache value used when session empty
  - **falls back to `"/"` when both stores are empty** (regression for #25)
  - honours `:fallback_target_url` app config

Closes #25