### PR TITLE
♻️ Refactor / Rewrite stale_time/1 in idiomatic Elixir (#14)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -3,14 +3,5 @@
   # Provably unreachable today, kept intentionally so the auth endpoint fails
   # closed (HTTP 403) if a future change introduces a new return shape.
   # See lib/ex_saml/sp_handler.ex for the inline rationale.
-  ~r/lib\/ex_saml\/sp_handler\.ex:95:.*pattern_match_cov/,
-
-  # `stale_time/1` step 1: the `if t == :none or secs < t` expression is
-  # tautologically true here because `t` is provably `:none` at this point
-  # (variable shadowing inside the `case` body — the new `t` is only bound
-  # after the case finishes). The structure is preserved verbatim from the
-  # upstream esaml `stale_time/1` to keep behavioral parity and ease future
-  # backports. See lib/ex_saml/core/saml.ex around line 798.
-  ~r/lib\/ex_saml\/core\/saml\.ex:803:28:pattern_match/,
-  ~r/lib\/ex_saml\/core\/saml\.ex:803:54:pattern_match/
+  ~r/lib\/ex_saml\/sp_handler\.ex:95:.*pattern_match_cov/
 ]

--- a/lib/ex_saml/core/saml.ex
+++ b/lib/ex_saml/core/saml.ex
@@ -792,10 +792,7 @@ defmodule ExSaml.Core.Saml do
   defp subject_expiry(_), do: nil
 
   defp conditions_expiry(%Assertion{conditions: conditions}) do
-    case Keyword.get(conditions, :not_on_or_after) do
-      nil -> nil
-      stamp -> to_secs(stamp)
-    end
+    if stamp = Keyword.get(conditions, :not_on_or_after), do: to_secs(stamp)
   end
 
   defp issue_instant_secs(%Assertion{issue_instant: stamp}), do: to_secs(stamp)

--- a/lib/ex_saml/core/saml.ex
+++ b/lib/ex_saml/core/saml.ex
@@ -780,55 +780,30 @@ defmodule ExSaml.Core.Saml do
   and falls back to issue_instant + 5 minutes.
   """
   @spec stale_time(Assertion.t()) :: integer()
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def stale_time(%Assertion{} = a) do
-    t = :none
-
-    t =
-      case a.subject do
-        %Subject{notonorafter: ""} ->
-          t
-
-        %Subject{notonorafter: restrict} ->
-          secs =
-            restrict
-            |> Util.saml_to_datetime()
-            |> :calendar.datetime_to_gregorian_seconds()
-
-          # Dialyzer flags this `if` as tautological because `t` is provably
-          # `:none` here (variable shadowing inside the `case` body). The
-          # structure is preserved verbatim from upstream arekinath/esaml's
-          # `stale_time/1` to keep behavioral parity and ease future backports.
-          # The corresponding warnings are suppressed in `.dialyzer_ignore.exs`.
-          if t == :none or secs < t, do: secs, else: t
-      end
-
-    t =
-      case Keyword.get(a.conditions, :not_on_or_after) do
-        nil ->
-          t
-
-        restrict ->
-          secs =
-            restrict
-            |> Util.saml_to_datetime()
-            |> :calendar.datetime_to_gregorian_seconds()
-
-          if t == :none or secs < t, do: secs, else: t
-      end
-
-    case t do
-      :none ->
-        ii_secs =
-          a.issue_instant
-          |> Util.saml_to_datetime()
-          |> :calendar.datetime_to_gregorian_seconds()
-
-        ii_secs + 5 * 60
-
-      _ ->
-        t
+    case Enum.reject([subject_expiry(a), conditions_expiry(a)], &is_nil/1) do
+      [] -> issue_instant_secs(a) + 5 * 60
+      candidates -> Enum.min(candidates)
     end
+  end
+
+  defp subject_expiry(%Assertion{subject: %Subject{notonorafter: ""}}), do: nil
+  defp subject_expiry(%Assertion{subject: %Subject{notonorafter: stamp}}), do: to_secs(stamp)
+  defp subject_expiry(_), do: nil
+
+  defp conditions_expiry(%Assertion{conditions: conditions}) do
+    case Keyword.get(conditions, :not_on_or_after) do
+      nil -> nil
+      stamp -> to_secs(stamp)
+    end
+  end
+
+  defp issue_instant_secs(%Assertion{issue_instant: stamp}), do: to_secs(stamp)
+
+  defp to_secs(stamp) do
+    stamp
+    |> Util.saml_to_datetime()
+    |> :calendar.datetime_to_gregorian_seconds()
   end
 
   @doc """

--- a/test/ex_saml/core/saml_test.exs
+++ b/test/ex_saml/core/saml_test.exs
@@ -526,6 +526,68 @@ defmodule ExSaml.Core.SamlTest do
   end
 
   # ---------------------------------------------------------------------------
+  # stale_time/1
+  # ---------------------------------------------------------------------------
+
+  describe "stale_time/1" do
+    defp gregorian(saml_stamp) do
+      saml_stamp
+      |> Util.saml_to_datetime()
+      |> :calendar.datetime_to_gregorian_seconds()
+    end
+
+    test "falls back to issue_instant + 5 minutes when neither subject nor conditions carry NotOnOrAfter" do
+      assertion = %Assertion{
+        issue_instant: "2026-01-01T00:00:00Z",
+        subject: %Subject{notonorafter: ""},
+        conditions: []
+      }
+
+      assert Saml.stale_time(assertion) == gregorian("2026-01-01T00:00:00Z") + 5 * 60
+    end
+
+    test "uses subject NotOnOrAfter when only subject restricts" do
+      assertion = %Assertion{
+        issue_instant: "2026-01-01T00:00:00Z",
+        subject: %Subject{notonorafter: "2026-01-01T00:10:00Z"},
+        conditions: []
+      }
+
+      assert Saml.stale_time(assertion) == gregorian("2026-01-01T00:10:00Z")
+    end
+
+    test "uses conditions NotOnOrAfter when only conditions restrict" do
+      assertion = %Assertion{
+        issue_instant: "2026-01-01T00:00:00Z",
+        subject: %Subject{notonorafter: ""},
+        conditions: [not_on_or_after: "2026-01-01T00:10:00Z"]
+      }
+
+      assert Saml.stale_time(assertion) == gregorian("2026-01-01T00:10:00Z")
+    end
+
+    test "returns the minimum when both restrictions are present (conditions earlier)" do
+      assertion = %Assertion{
+        issue_instant: "2026-01-01T00:00:00Z",
+        subject: %Subject{notonorafter: "2026-01-01T00:15:00Z"},
+        conditions: [not_on_or_after: "2026-01-01T00:05:00Z"]
+      }
+
+      assert Saml.stale_time(assertion) == gregorian("2026-01-01T00:05:00Z")
+    end
+
+    test "returns the minimum when both restrictions are present (subject earlier)" do
+      assertion = %Assertion{
+        issue_instant: "2026-01-01T00:00:00Z",
+        subject: %Subject{notonorafter: "2026-01-01T00:05:00Z"},
+        conditions: [not_on_or_after: "2026-01-01T00:15:00Z"]
+      }
+
+      assert Saml.stale_time(assertion) == gregorian("2026-01-01T00:05:00Z")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # validate_stale_assertion
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #14 (scoped to `stale_time/1`; broader esaml-port audit deferred — see below).

Rewrites `ExSaml.Core.Saml.stale_time/1` to drop the verbatim-from-`arekinath/esaml` structure that relied on variable shadowing inside nested `case` blocks. That shadowing made an inner branch tautological for Dialyzer and forced two `pattern_match` suppressions in `.dialyzer_ignore.exs`.

The new form:

- Collects candidate expiries (`subject.notonorafter`, `conditions[:not_on_or_after]`) into a list, rejects `nil`, takes `Enum.min/1`.
- Falls back to `issue_instant + 5 * 60` when neither restriction is present.
- Same contract — `@spec stale_time(Assertion.t()) :: integer()` — same behavior, no shadowing.
- Removes the `# credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity` directive (no longer needed).
- Removes the two `lib/ex_saml/core/saml.ex:803` entries from `.dialyzer_ignore.exs`. The `sp_handler.ex:95` defensive entry stays (out of scope, deliberate catch-all).

## Tests

Adds a new `describe "stale_time/1"` block in `test/ex_saml/core/saml_test.exs` with five cases:

- Fallback to `issue_instant + 5 min` when neither subject nor conditions carry `NotOnOrAfter`.
- Subject-only restriction.
- Conditions-only restriction.
- Both present, conditions earlier — returns conditions seconds.
- Both present, subject earlier — returns subject seconds.

These tests were written **before** the refactor and validated against the old implementation first, confirming behavioral parity.

## Scope note

Issue #14 also asks to audit other esaml-ported functions for similar patterns. The audit found that `decode_response/1`, `decode_assertion/1`, `decode_logout_request/1`, `to_xml/1` etc. already use idiomatic Elixir (`with`, `Enum.reduce`, functional accumulators). `stale_time/1` was the only function forcing Dialyzer suppressions due to esaml-style code. A follow-up issue can track any additional cosmetic cleanup if desired.

## Test plan

- [x] `mix test` — 204 tests, 0 failures
- [x] `mix credo --strict lib/ex_saml/core/saml.ex` — no issues
- [x] `mix dialyzer` — passed, 0 unnecessary skips (confirms the `sp_handler.ex:95` entry is still needed and the removed `saml.ex:803` entries were the only ones tied to this refactor)