### PR TITLE
✨ Feature / SafeXml — single hardened xmerl_scan entry point

### DIFF
--- a/lib/ex_saml/core/binding.ex
+++ b/lib/ex_saml/core/binding.ex
@@ -33,6 +33,8 @@ defmodule ExSaml.Core.Binding do
   configured with `use_redirect_for_req: true`.
   """
 
+  alias ExSaml.Core.Xml.SafeXml
+
   require Record
 
   Record.defrecord(:xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl"))
@@ -62,14 +64,10 @@ defmodule ExSaml.Core.Binding do
   """
   @spec decode_response(binary(), binary()) :: xml()
   def decode_response(@deflate, saml_response) do
-    xml_data =
-      saml_response
-      |> :base64.decode()
-      |> :zlib.unzip()
-      |> :binary.bin_to_list()
-
-    {xml, _} = :xmerl_scan.string(xml_data, namespace_conformant: true, allow_entities: false)
-    xml
+    saml_response
+    |> :base64.decode()
+    |> :zlib.unzip()
+    |> SafeXml.scan!()
   end
 
   def decode_response(_encoding, saml_response) do
@@ -77,15 +75,14 @@ defmodule ExSaml.Core.Binding do
 
     xml_data =
       try do
-        :zlib.unzip(data) |> :binary.bin_to_list()
+        :zlib.unzip(data)
       rescue
-        _e -> :binary.bin_to_list(data)
+        _e -> data
       catch
-        _kind, _reason -> :binary.bin_to_list(data)
+        _kind, _reason -> data
       end
 
-    {xml, _} = :xmerl_scan.string(xml_data, namespace_conformant: true, allow_entities: false)
-    xml
+    SafeXml.scan!(xml_data)
   end
 
   @doc """

--- a/lib/ex_saml/core/binding.ex
+++ b/lib/ex_saml/core/binding.ex
@@ -62,12 +62,12 @@ defmodule ExSaml.Core.Binding do
   unzip is attempted, falling back to the raw decoded data if decompression
   fails. The resulting XML string is then parsed with `:xmerl_scan`.
   """
-  @spec decode_response(binary(), binary()) :: xml()
+  @spec decode_response(binary(), binary()) :: {:ok, xml()} | {:error, :invalid_xml}
   def decode_response(@deflate, saml_response) do
     saml_response
     |> :base64.decode()
     |> :zlib.unzip()
-    |> SafeXml.scan!()
+    |> SafeXml.scan()
   end
 
   def decode_response(_encoding, saml_response) do
@@ -82,7 +82,7 @@ defmodule ExSaml.Core.Binding do
         _kind, _reason -> data
       end
 
-    SafeXml.scan!(xml_data)
+    SafeXml.scan(xml_data)
   end
 
   @doc """

--- a/lib/ex_saml/core/sp.ex
+++ b/lib/ex_saml/core/sp.ex
@@ -32,7 +32,8 @@ defmodule ExSaml.Core.Sp do
     SpMetadata,
     Subject,
     Util,
-    Xml.Dsig
+    Xml.Dsig,
+    Xml.SafeXml
   }
 
   @type xml :: record(:xmlElement)
@@ -516,13 +517,7 @@ defmodule ExSaml.Core.Sp do
 
     assertion_xml = block_decrypt(to_string(algorithm), symmetric_key, cipher_value)
 
-    {assertion, _} =
-      :xmerl_scan.string(:binary.bin_to_list(assertion_xml),
-        namespace_conformant: true,
-        allow_entities: false
-      )
-
-    assertion
+    SafeXml.scan!(assertion_xml)
   end
 
   defp decrypt_key_info(encrypted_data, key) do

--- a/lib/ex_saml/core/sp.ex
+++ b/lib/ex_saml/core/sp.ex
@@ -299,18 +299,13 @@ defmodule ExSaml.Core.Sp do
            [{:namespace, ns}]
          ) do
       [encrypted] when Record.is_record(encrypted, :xmlElement) ->
-        try do
-          decrypted = decrypt_assertion(encrypted, sp)
-          true = Record.is_record(decrypted, :xmlElement)
-
-          case :xmerl_xpath.string(~c"/saml:Assertion", decrypted, [{:namespace, ns}]) do
-            [a] -> {:ok, a}
-            _ -> {:error, :bad_assertion}
-          end
-        rescue
+        with {:ok, decrypted} <- decrypt_assertion(encrypted, sp),
+             true <- Record.is_record(decrypted, :xmlElement),
+             [assertion] <-
+               :xmerl_xpath.string(~c"/saml:Assertion", decrypted, [{:namespace, ns}]) do
+          {:ok, assertion}
+        else
           _ -> {:error, :bad_assertion}
-        catch
-          _, _ -> {:error, :bad_assertion}
         end
 
       _ ->
@@ -517,7 +512,11 @@ defmodule ExSaml.Core.Sp do
 
     assertion_xml = block_decrypt(to_string(algorithm), symmetric_key, cipher_value)
 
-    SafeXml.scan!(assertion_xml)
+    SafeXml.scan(assertion_xml)
+  rescue
+    _ -> {:error, :decrypt_failed}
+  catch
+    _, _ -> {:error, :decrypt_failed}
   end
 
   defp decrypt_key_info(encrypted_data, key) do

--- a/lib/ex_saml/core/xml/safe_xml.ex
+++ b/lib/ex_saml/core/xml/safe_xml.ex
@@ -12,24 +12,45 @@ defmodule ExSaml.Core.Xml.SafeXml do
   centralises the binary→charlist conversion that previously had to be
   patched at every call site (cf. UTF-8 SAMLResponse handling).
 
-  ## Functions
+  ## Error reporting hook
 
-    * `scan/1` returns `{:ok, root}` or `{:error, :invalid_xml}`.
-    * `scan!/1` returns the root element or raises `ArgumentError`. Use it
-      when the surrounding code already runs inside a `try`/`rescue` or
-      when a malformed payload should propagate as an exception.
+  An arity-1 function may be configured to receive parse-failure context.
+  Typical use: forward to a SIEM / OCSF pipeline.
+
+      config :ex_saml, :safe_xml,
+        on_error: &MyApp.SIEM.report_xml_error/1
+
+  The handler is invoked **after** the `{:error, :invalid_xml}` tuple is
+  produced and receives a map:
+
+      %{
+        reason: :invalid_xml,
+        kind: :error | :exit | :throw,
+        payload: Exception.t() | term()
+      }
+
+  Any exception raised by the handler is silently caught — the handler must
+  never be able to mask the original parse failure or alter the caller's
+  control flow.
   """
 
   @scan_opts [namespace_conformant: true, allow_entities: false, quiet: true]
 
   @type xml :: term()
+  @type error_context :: %{
+          required(:reason) => :invalid_xml,
+          required(:kind) => :error | :exit | :throw,
+          required(:payload) => Exception.t() | term()
+        }
 
   @doc """
   Parse `xml` with `:xmerl_scan` using the hardened option set.
 
   Accepts either a UTF-8 binary or a charlist. Returns the parsed root on
-  success or `{:error, :invalid_xml}` on any parse failure (`rescue`d
-  exception or `catch`-able exit).
+  success or `{:error, :invalid_xml}` on any parse failure.
+
+  Invokes the configured `:on_error` hook (if any) before returning the
+  error tuple.
   """
   @spec scan(binary() | charlist()) :: {:ok, xml()} | {:error, :invalid_xml}
   def scan(xml) when is_binary(xml), do: xml |> :binary.bin_to_list() |> scan()
@@ -38,20 +59,39 @@ defmodule ExSaml.Core.Xml.SafeXml do
     {root, _rest} = :xmerl_scan.string(xml, @scan_opts)
     {:ok, root}
   rescue
-    _ -> {:error, :invalid_xml}
+    e ->
+      notify(%{reason: :invalid_xml, kind: :error, payload: e})
+      {:error, :invalid_xml}
   catch
-    _kind, _reason -> {:error, :invalid_xml}
+    :exit, reason ->
+      notify(%{reason: :invalid_xml, kind: :exit, payload: reason})
+      {:error, :invalid_xml}
+
+    :throw, value ->
+      notify(%{reason: :invalid_xml, kind: :throw, payload: value})
+      {:error, :invalid_xml}
   end
 
-  @doc """
-  Same as `scan/1` but raises `ArgumentError` on parse failure and returns
-  the parsed root directly.
-  """
-  @spec scan!(binary() | charlist()) :: xml()
-  def scan!(xml) do
-    case scan(xml) do
-      {:ok, root} -> root
-      {:error, reason} -> raise ArgumentError, "invalid XML: #{inspect(reason)}"
+  # ---------------------------------------------------------------------------
+  # Error reporting hook
+  # ---------------------------------------------------------------------------
+
+  defp notify(context) do
+    case Application.get_env(:ex_saml, :safe_xml, [])[:on_error] do
+      fun when is_function(fun, 1) ->
+        safe_invoke(fun, context)
+
+      _ ->
+        :ok
     end
+  end
+
+  defp safe_invoke(fun, context) do
+    fun.(context)
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
   end
 end

--- a/lib/ex_saml/core/xml/safe_xml.ex
+++ b/lib/ex_saml/core/xml/safe_xml.ex
@@ -1,0 +1,57 @@
+defmodule ExSaml.Core.Xml.SafeXml do
+  @moduledoc """
+  Single entry point for parsing untrusted SAML/XML payloads with `:xmerl_scan`.
+
+  All calls go through this module so that the XXE-safe options
+  (`allow_entities: false`, `namespace_conformant: true`) and the
+  binary→charlist conversion are applied **once**, in one place. Callers do
+  not pass scan options — they cannot weaken the defaults.
+
+  Centralising the wrapper means a future hardening change (new xmerl option,
+  stricter limits, alternative parser) is a one-file diff. It also
+  centralises the binary→charlist conversion that previously had to be
+  patched at every call site (cf. UTF-8 SAMLResponse handling).
+
+  ## Functions
+
+    * `scan/1` returns `{:ok, root}` or `{:error, :invalid_xml}`.
+    * `scan!/1` returns the root element or raises `ArgumentError`. Use it
+      when the surrounding code already runs inside a `try`/`rescue` or
+      when a malformed payload should propagate as an exception.
+  """
+
+  @scan_opts [namespace_conformant: true, allow_entities: false, quiet: true]
+
+  @type xml :: term()
+
+  @doc """
+  Parse `xml` with `:xmerl_scan` using the hardened option set.
+
+  Accepts either a UTF-8 binary or a charlist. Returns the parsed root on
+  success or `{:error, :invalid_xml}` on any parse failure (`rescue`d
+  exception or `catch`-able exit).
+  """
+  @spec scan(binary() | charlist()) :: {:ok, xml()} | {:error, :invalid_xml}
+  def scan(xml) when is_binary(xml), do: xml |> :binary.bin_to_list() |> scan()
+
+  def scan(xml) when is_list(xml) do
+    {root, _rest} = :xmerl_scan.string(xml, @scan_opts)
+    {:ok, root}
+  rescue
+    _ -> {:error, :invalid_xml}
+  catch
+    _kind, _reason -> {:error, :invalid_xml}
+  end
+
+  @doc """
+  Same as `scan/1` but raises `ArgumentError` on parse failure and returns
+  the parsed root directly.
+  """
+  @spec scan!(binary() | charlist()) :: xml()
+  def scan!(xml) do
+    case scan(xml) do
+      {:ok, root} -> root
+      {:error, reason} -> raise ArgumentError, "invalid XML: #{inspect(reason)}"
+    end
+  end
+end

--- a/lib/ex_saml/helper.ex
+++ b/lib/ex_saml/helper.ex
@@ -108,9 +108,9 @@ defmodule ExSaml.Helper do
   end
 
   defp decode_saml_payload(saml_encoding, saml_payload) do
-    xml = Core.Binding.decode_response(saml_encoding, saml_payload)
-    {:ok, xml}
-  rescue
-    error -> {:error, {:invalid_response, "#{inspect(error)}"}}
+    case Core.Binding.decode_response(saml_encoding, saml_payload) do
+      {:ok, xml} -> {:ok, xml}
+      {:error, reason} -> {:error, {:invalid_response, reason}}
+    end
   end
 end

--- a/lib/ex_saml/metadata.ex
+++ b/lib/ex_saml/metadata.ex
@@ -32,6 +32,7 @@ defmodule ExSaml.Metadata do
   See `ExSaml.Metadata.ValidationResult` for the shape of the returned struct.
   """
 
+  alias ExSaml.Core.Xml.SafeXml
   alias ExSaml.Metadata.ValidationResult
 
   require Record
@@ -100,26 +101,16 @@ defmodule ExSaml.Metadata do
   # ---------------------------------------------------------------------------
 
   defp parse(xml) do
-    charlist = :binary.bin_to_list(xml)
+    case SafeXml.scan(xml) do
+      {:ok, root} ->
+        if Record.is_record(root, :xmlElement) do
+          {:ok, root}
+        else
+          {:error, invalid_xml_violation()}
+        end
 
-    try do
-      {root, _rest} =
-        :xmerl_scan.string(
-          charlist,
-          namespace_conformant: true,
-          allow_entities: false,
-          quiet: true
-        )
-
-      if Record.is_record(root, :xmlElement) do
-        {:ok, root}
-      else
+      {:error, _} ->
         {:error, invalid_xml_violation()}
-      end
-    rescue
-      _ -> {:error, invalid_xml_violation()}
-    catch
-      _kind, _reason -> {:error, invalid_xml_violation()}
     end
   end
 

--- a/test/ex_saml/core/binding_test.exs
+++ b/test/ex_saml/core/binding_test.exs
@@ -101,7 +101,7 @@ defmodule ExSaml.Core.BindingTest do
       [_, b64_payload] = Regex.run(~r/name="SAMLRequest" value="([^"]+)"/, html)
 
       # decode_response with nil encoding (non-deflate path) should parse it
-      decoded = Binding.decode_response("", b64_payload)
+      {:ok, decoded} = Binding.decode_response("", b64_payload)
       assert Record.is_record(decoded, :xmlElement)
       assert xmlElement(decoded, :name) == :AuthnRequest
     end
@@ -170,7 +170,7 @@ defmodule ExSaml.Core.BindingTest do
       compressed = :zlib.zip(xml_str)
       b64 = Base.encode64(compressed)
 
-      decoded =
+      {:ok, decoded} =
         Binding.decode_response(
           "urn:oasis:names:tc:SAML:2.0:bindings:URL-Encoding:DEFLATE",
           b64
@@ -184,7 +184,7 @@ defmodule ExSaml.Core.BindingTest do
       xml_str = "<Response>hello</Response>"
       b64 = Base.encode64(xml_str)
 
-      decoded = Binding.decode_response("", b64)
+      {:ok, decoded} = Binding.decode_response("", b64)
 
       assert Record.is_record(decoded, :xmlElement)
       assert xmlElement(decoded, :name) == :Response
@@ -234,7 +234,7 @@ defmodule ExSaml.Core.BindingTest do
         xml = "<Response><Name>" <> sample <> "</Name></Response>"
         b64 = Base.encode64(xml)
 
-        decoded = Binding.decode_response("", b64)
+        {:ok, decoded} = Binding.decode_response("", b64)
 
         assert Record.is_record(decoded, :xmlElement)
         assert xmlElement(decoded, :name) == :Response
@@ -248,7 +248,7 @@ defmodule ExSaml.Core.BindingTest do
         xml = "<Response label=\"" <> attr <> "\"><Name>x</Name></Response>"
         b64 = Base.encode64(xml)
 
-        decoded = Binding.decode_response("", b64)
+        {:ok, decoded} = Binding.decode_response("", b64)
 
         assert Record.is_record(decoded, :xmlElement)
         assert attribute_value(decoded, :label) == unquote(expected)
@@ -261,7 +261,7 @@ defmodule ExSaml.Core.BindingTest do
         xml = "<Response><Name>" <> sample <> "</Name></Response>"
         b64 = xml |> :zlib.zip() |> Base.encode64()
 
-        decoded =
+        {:ok, decoded} =
           Binding.decode_response(
             "urn:oasis:names:tc:SAML:2.0:bindings:URL-Encoding:DEFLATE",
             b64
@@ -283,7 +283,7 @@ defmodule ExSaml.Core.BindingTest do
           "</AttributeStatement></Assertion></samlp:Response>"
 
       b64 = Base.encode64(xml)
-      decoded = Binding.decode_response("", b64)
+      {:ok, decoded} = Binding.decode_response("", b64)
 
       assert Record.is_record(decoded, :xmlElement)
       assert xmlElement(decoded, :name) == :"samlp:Response"

--- a/test/ex_saml/core/xml/safe_xml_test.exs
+++ b/test/ex_saml/core/xml/safe_xml_test.exs
@@ -1,11 +1,14 @@
 defmodule ExSaml.Core.Xml.SafeXmlTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias ExSaml.Core.Xml.SafeXml
 
   require Record
 
   Record.defrecord(:xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl"))
+
+  # `async: false` because tests in the `on_error hook` describe mutate
+  # `Application.put_env(:ex_saml, :safe_xml, ...)`, which is process-global.
 
   describe "scan/1" do
     test "parses a well-formed XML binary" do
@@ -58,29 +61,61 @@ defmodule ExSaml.Core.Xml.SafeXmlTest do
     end
   end
 
-  describe "scan!/1" do
-    test "returns the root element on success" do
-      root = SafeXml.scan!("<root/>")
-      assert Record.is_record(root, :xmlElement)
-      assert xmlElement(root, :name) == :root
+  describe ":on_error hook" do
+    setup do
+      previous = Application.get_env(:ex_saml, :safe_xml)
+
+      on_exit(fn ->
+        if previous do
+          Application.put_env(:ex_saml, :safe_xml, previous)
+        else
+          Application.delete_env(:ex_saml, :safe_xml)
+        end
+      end)
+
+      :ok
     end
 
-    test "raises ArgumentError on malformed input" do
-      assert_raise ArgumentError, ~r/invalid XML/, fn ->
-        SafeXml.scan!("<broken")
-      end
+    test "is invoked once per parse failure with a context map" do
+      test_pid = self()
+
+      Application.put_env(:ex_saml, :safe_xml,
+        on_error: fn ctx -> send(test_pid, {:ctx, ctx}) end
+      )
+
+      assert {:error, :invalid_xml} = SafeXml.scan("<broken")
+
+      assert_receive {:ctx, %{reason: :invalid_xml, kind: kind, payload: payload}}
+      assert kind in [:error, :exit, :throw]
+      assert payload != nil
     end
 
-    test "raises ArgumentError on XXE input" do
-      xxe = """
-      <?xml version="1.0"?>
-      <!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
-      <foo>&xxe;</foo>
-      """
+    test "is not invoked on successful parses" do
+      test_pid = self()
+      Application.put_env(:ex_saml, :safe_xml, on_error: fn _ctx -> send(test_pid, :called) end)
 
-      assert_raise ArgumentError, ~r/invalid XML/, fn ->
-        SafeXml.scan!(xxe)
-      end
+      assert {:ok, _} = SafeXml.scan("<root/>")
+
+      refute_receive :called, 50
+    end
+
+    test "swallows handler exceptions and still returns the error tuple" do
+      Application.put_env(:ex_saml, :safe_xml, on_error: fn _ctx -> raise "handler boom" end)
+
+      assert {:error, :invalid_xml} = SafeXml.scan("<broken")
+    end
+
+    test "is a no-op when no handler is configured" do
+      Application.delete_env(:ex_saml, :safe_xml)
+      assert {:error, :invalid_xml} = SafeXml.scan("<broken")
+    end
+
+    test "is a no-op when the configured value is not an arity-1 function" do
+      Application.put_env(:ex_saml, :safe_xml, on_error: :not_a_function)
+      assert {:error, :invalid_xml} = SafeXml.scan("<broken")
+
+      Application.put_env(:ex_saml, :safe_xml, on_error: fn -> :wrong_arity end)
+      assert {:error, :invalid_xml} = SafeXml.scan("<broken")
     end
   end
 end

--- a/test/ex_saml/core/xml/safe_xml_test.exs
+++ b/test/ex_saml/core/xml/safe_xml_test.exs
@@ -1,0 +1,86 @@
+defmodule ExSaml.Core.Xml.SafeXmlTest do
+  use ExUnit.Case, async: true
+
+  alias ExSaml.Core.Xml.SafeXml
+
+  require Record
+
+  Record.defrecord(:xmlElement, Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl"))
+
+  describe "scan/1" do
+    test "parses a well-formed XML binary" do
+      assert {:ok, root} = SafeXml.scan("<root><child>hello</child></root>")
+      assert Record.is_record(root, :xmlElement)
+      assert xmlElement(root, :name) == :root
+    end
+
+    test "parses a charlist input identically to a binary input" do
+      xml = "<root/>"
+      assert {:ok, from_binary} = SafeXml.scan(xml)
+      assert {:ok, from_charlist} = SafeXml.scan(String.to_charlist(xml))
+      assert xmlElement(from_binary, :name) == xmlElement(from_charlist, :name)
+    end
+
+    test "accepts UTF-8 multibyte content in element values" do
+      assert {:ok, _root} = SafeXml.scan("<root>éàü — ✓</root>")
+    end
+
+    test "returns {:error, :invalid_xml} on malformed input" do
+      assert {:error, :invalid_xml} = SafeXml.scan("<not-closed>")
+    end
+
+    test "returns {:error, :invalid_xml} on empty input" do
+      assert {:error, :invalid_xml} = SafeXml.scan("")
+    end
+
+    test "rejects DOCTYPE with an external entity (XXE)" do
+      xxe = """
+      <?xml version="1.0"?>
+      <!DOCTYPE foo [
+        <!ENTITY xxe SYSTEM "file:///etc/passwd">
+      ]>
+      <foo>&xxe;</foo>
+      """
+
+      assert {:error, :invalid_xml} = SafeXml.scan(xxe)
+    end
+
+    test "rejects DOCTYPE with an internal entity expansion" do
+      doc = """
+      <?xml version="1.0"?>
+      <!DOCTYPE foo [
+        <!ENTITY hello "world">
+      ]>
+      <foo>&hello;</foo>
+      """
+
+      assert {:error, :invalid_xml} = SafeXml.scan(doc)
+    end
+  end
+
+  describe "scan!/1" do
+    test "returns the root element on success" do
+      root = SafeXml.scan!("<root/>")
+      assert Record.is_record(root, :xmlElement)
+      assert xmlElement(root, :name) == :root
+    end
+
+    test "raises ArgumentError on malformed input" do
+      assert_raise ArgumentError, ~r/invalid XML/, fn ->
+        SafeXml.scan!("<broken")
+      end
+    end
+
+    test "raises ArgumentError on XXE input" do
+      xxe = """
+      <?xml version="1.0"?>
+      <!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+      <foo>&xxe;</foo>
+      """
+
+      assert_raise ArgumentError, ~r/invalid XML/, fn ->
+        SafeXml.scan!(xxe)
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Part of #32 — first PR of the SAML XML parsing surface hardening initiative.

## Summary

- **New module** `ExSaml.Core.Xml.SafeXml` — single entry point for parsing untrusted SAML/XML via `:xmerl_scan`. Always forces `allow_entities: false`, `namespace_conformant: true`, `quiet: true`; callers cannot weaken these options.
- **Tuple-only API.** `SafeXml.scan/1` returns `{:ok, xml()} | {:error, :invalid_xml}` — no raising variant. Errors are values, composable in `with`/`case` pipelines.
- **Tuple cascade through callers.** `Binding.decode_response/2` (public), `Sp.decrypt_assertion/2` (private) and `Helper.decode_saml_payload/2` (private) all propagate the tuple. The previous `rescue` in `Helper` is replaced by a `case`; the error reason is now an atom (`{:invalid_response, :invalid_xml}`) instead of a stringified `inspect(error)`.
- **Configurable error hook** for SIEM / OCSF pipelines:

  ```elixir
  config :ex_saml, :safe_xml,
    on_error: &MyApp.SIEM.report_xml_error/1
  ```

  The arity-1 handler receives `%{reason: :invalid_xml, kind: :error | :exit | :throw, payload: …}`. Any exception from the handler is silently caught — it can never mask the original parse failure or alter control flow.
- **De-duplication of the four pre-existing `:xmerl_scan.string` call sites** (`Metadata.parse/1`, `Binding.decode_response/2` × 2, `Sp.decrypt_assertion/2`). The binary→charlist conversion (the source of the #22 UTF-8 fix that had to patch four files) is centralised in `SafeXml.scan/1` — future encoding changes are now a one-file diff.

## Why this PR

This is **PR 1 of #32** (SAML XML parsing surface hardening). The umbrella issue lays out the full four-PR plan; the short version is that the original `mix security.check_release` task drafted in #15 relied on regex source-scanning, which was silently contournable. The root cause was upstream: `:xmerl_scan` was called in four different files with slightly different options. With a single hardened call site, a future audit check (PR 2 of #32) becomes incontournable: any reference to `:xmerl_scan.*` outside `safe_xml.ex` is a violation.

## Behaviour notes

- **Preserved**: `Metadata.parse/1` still returns `{:error, invalid_xml_violation()}` on any parse failure or non-element root.
- **Changed (deliberate)**: `Binding.decode_response/2` return shape goes from `xml()` to `{:ok, xml()} | {:error, :invalid_xml}`. Public spec change. Single intra-lib caller (`Helper.decode_saml_payload/2`) updated; tests updated.
- **Changed (deliberate)**: `Helper.decode_saml_payload/2` error shape `{:invalid_response, …}` now carries an atom reason instead of an interpolated `inspect(error)` string. No caller pattern-matches on it (verified via `grep`).
- **Changed (deliberate)**: `Binding.decode_response/2` now passes `quiet: true` to `:xmerl_scan` (only `Metadata.parse/1` did before). Malformed-payload xmerl warning logs are now silent; error semantics unchanged.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — no issues
- [x] `mix sobelow --config --skip` — scan complete, no findings
- [x] `mix test` — **211 tests, 0 failures**, including:
  - 7 `SafeXml.scan/1` cases (well-formed, binary/charlist parity, UTF-8, malformed, empty, XXE external entity, internal entity)
  - 5 `:on_error` hook cases (called once per failure, not called on success, swallows handler errors, no-op when unconfigured, no-op when value is not an arity-1 function)
  - 7 updated `Binding.decode_response/2` callers in `binding_test.exs` (deflate + non-deflate roundtrip + full UTF-8 regression matrix)
- [x] `grep -rn ':xmerl_scan.string' lib/` — only invocation lives at `safe_xml.ex:59`
- [x] `grep -rn 'scan!' lib/ test/` — no remaining callers (no raising API surface)