### PR TITLE
🔖 Release / v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-19
+
+### Fixed
+
+- IdP-initiated SSO flow no longer rejects all valid Responses with `:access_denied`. `validate_authresp/4` returned the bare atom `:ok` on the IdP-initiated success branch while the caller pattern-matched `{:ok, nonce}` inside `with`, making the whole success path dead code whenever `allow_idp_initiated_flow: true`. The function now returns `{:ok, flow, nonce}` (with `flow` ∈ `{:idp_initiated, :sp_initiated}` and `nonce: nil` for IdP-initiated), and `consume_signin_response/2` exposes a new `flow:` field in its success map so consumers no longer have to deduce the flow type from `nonce == nil` (#27, closes #24)
+- `ExSaml.SPHandler.send_saml_response/3` no longer crashes with `Plug.Conn.AlreadySentError` (or a `nil` URL `ArgumentError`) when authentication fails and the target URL cannot be resolved. The error path now renders an HTML 403 response instead of attempting a redirect to a missing location (#26)
+
+### Changed
+
+- `consume_signin_response/2` success map now includes a `flow:` field (`:sp_initiated` or `:idp_initiated`). Additive — existing keys are unchanged (#27)
+- Error atom `:idp_first_flow_not_allowed` renamed to `:idp_initiated_not_allowed` to align with standard SAML terminology used elsewhere in the module. In practice the previous atom was unobservable because the IdP-initiated flow itself was broken (#27)
+- Internal `stale_time/1` rewritten in idiomatic Elixir — drops the verbatim-from-esaml nested-`case` structure with variable shadowing in favor of an `Enum.min/1` over collected candidate expiries. Same contract, with dedicated unit tests covering all three branches (#28, #14)
+
 ## [1.1.0] - 2026-05-06
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExSaml.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/docJerem/ex_saml"
-  @version "1.1.0"
+  @version "1.1.1"
 
   def project do
     [


### PR DESCRIPTION
## Summary

Patch release bundling the three commits merged since `v1.1.0` (2026-05-06).

### Fixed
- IdP-initiated SSO flow no longer rejects all valid Responses with `:access_denied` — `validate_authresp/4` now returns `{:ok, flow, nonce}` and `consume_signin_response/2` exposes a `flow:` field in its success map (#27, closes #24)
- `ExSaml.SPHandler.send_saml_response/3` no longer crashes on `nil` target URL in the SAML error path — renders an HTML 403 instead of attempting a redirect (#26)

### Changed
- `consume_signin_response/2` success map gains an additive `flow:` field (`:sp_initiated` or `:idp_initiated`) (#27)
- Error atom `:idp_first_flow_not_allowed` → `:idp_initiated_not_allowed` for alignment with standard SAML terminology. Unobservable in practice — the IdP-initiated flow itself was broken before #27 (#27)
- Internal `stale_time/1` rewritten in idiomatic Elixir, drops two dialyzer suppressions, adds dedicated unit tests (#28, #14)

## Test plan

- [x] `mix test` green
- [x] `mix dialyzer` clean
- [x] `mix credo --strict` clean
- [x] CHANGELOG and `@version` in `mix.exs` agree on `1.1.1`
- [ ] After merge: tag `v1.1.1` on `main` and `mix hex.publish`