### PR TITLE
✨ Feature / Metadata validation — certificate and ds:Signature structure rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ExSaml.Metadata.validate/2` now reports certificate-level violations on every `<md:KeyDescriptor>`: `:missing_x509_certificate`, `:invalid_x509_certificate`, `:certificate_expired` (the last is silence-able via `:ignore`) (#17)
+- `ExSaml.Metadata.validate/2` now reports XML-DSig structure violations on every `<ds:Signature>` declared in metadata: `:invalid_signature_structure`, `:unknown_signature_algorithm`, `:unknown_digest_algorithm`. Cryptographic verification remains out of scope (#17)
+
 ## [1.1.0] - 2026-05-06
 
 ### Added

--- a/lib/ex_saml/metadata.ex
+++ b/lib/ex_saml/metadata.ex
@@ -33,6 +33,7 @@ defmodule ExSaml.Metadata do
   """
 
   alias ExSaml.Metadata.Certificate
+  alias ExSaml.Metadata.Signature
   alias ExSaml.Metadata.ValidationResult
 
   require Record
@@ -176,7 +177,8 @@ defmodule ExSaml.Metadata do
   defp check_entity_descriptor(root) do
     entity_id_violations(root) ++
       descriptor_violations(root) ++
-      Certificate.violations(root, @namespaces)
+      Certificate.violations(root, @namespaces) ++
+      Signature.violations(root, @namespaces)
   end
 
   defp entity_id_violations(root) do

--- a/lib/ex_saml/metadata.ex
+++ b/lib/ex_saml/metadata.ex
@@ -32,6 +32,7 @@ defmodule ExSaml.Metadata do
   See `ExSaml.Metadata.ValidationResult` for the shape of the returned struct.
   """
 
+  alias ExSaml.Metadata.Certificate
   alias ExSaml.Metadata.ValidationResult
 
   require Record
@@ -173,7 +174,9 @@ defmodule ExSaml.Metadata do
   # ---------------------------------------------------------------------------
 
   defp check_entity_descriptor(root) do
-    entity_id_violations(root) ++ descriptor_violations(root)
+    entity_id_violations(root) ++
+      descriptor_violations(root) ++
+      Certificate.violations(root, @namespaces)
   end
 
   defp entity_id_violations(root) do

--- a/lib/ex_saml/metadata.ex
+++ b/lib/ex_saml/metadata.ex
@@ -10,7 +10,41 @@ defmodule ExSaml.Metadata do
 
   This module currently implements **spec-conformance rules only** — every
   finding is an `:error`. Best-practice rules (warnings, strict mode,
-  certificate linting) are added in subsequent releases.
+  domain-mismatch lint) are added in subsequent releases.
+
+  ## Violation codes emitted by this version
+
+  Structural rules (root, descriptors, endpoints):
+
+    * `:invalid_xml`
+    * `:invalid_root_element`
+    * `:entities_descriptor_not_supported`
+    * `:missing_entity_id`
+    * `:entity_id_too_long`
+    * `:missing_role_descriptor`
+    * `:missing_saml2_protocol_support`
+    * `:missing_acs`
+    * `:missing_sso_service`
+    * `:invalid_acs_binding`
+    * `:missing_http_post_acs`
+    * `:duplicate_acs_index`
+    * `:multiple_default_acs`
+    * `:invalid_slo_binding`
+
+  Certificate rules (every `<md:KeyDescriptor>`):
+
+    * `:missing_x509_certificate`
+    * `:invalid_x509_certificate`
+    * `:certificate_expired` — silence-able via `:ignore` for legacy scenarios
+
+  Signature-structure rules (every `<ds:Signature>` declared in metadata):
+
+    * `:invalid_signature_structure`
+    * `:unknown_signature_algorithm`
+    * `:unknown_digest_algorithm`
+
+  Cryptographic verification of `<ds:Signature>` against a trust anchor is
+  intentionally out of scope.
 
   ## Example
 

--- a/lib/ex_saml/metadata/certificate.ex
+++ b/lib/ex_saml/metadata/certificate.ex
@@ -1,23 +1,23 @@
 defmodule ExSaml.Metadata.Certificate do
-  @moduledoc false
+  @moduledoc """
+  Certificate-level metadata validation rules.
 
-  # Certificate-level metadata validation rules.
-  #
-  # Iterates every `<md:KeyDescriptor>` declared under an `<md:SPSSODescriptor>`
-  # or `<md:IDPSSODescriptor>` and emits violations for the structural and
-  # validity expectations of PR 2:
-  #
-  #   * `:missing_x509_certificate` — KeyDescriptor without a non-empty
-  #     `<ds:X509Certificate>` text node.
-  #   * `:invalid_x509_certificate` — text that does not decode as base64 DER
-  #     or whose ASN.1 structure cannot be parsed by `:public_key`.
-  #   * `:certificate_expired` — parseable certificate whose `notAfter` is in
-  #     the past relative to `DateTime.utc_now/0`. Silence-able via
-  #     `ExSaml.Metadata.validate/2`'s `:ignore` option.
-  #
-  # Best-practice rules that depend on certificate inspection (CA detection,
-  # KeyUsage linting, shared signing/encryption certificate) live in the next
-  # batch of rules alongside strict-mode plumbing — see issue #17 PR 3.
+  Iterates every `<md:KeyDescriptor>` declared under an `<md:SPSSODescriptor>`
+  or `<md:IDPSSODescriptor>` and emits violations for the structural and
+  validity expectations of PR 2:
+
+    * `:missing_x509_certificate` — KeyDescriptor without a non-empty
+      `<ds:X509Certificate>` text node.
+    * `:invalid_x509_certificate` — text that does not decode as base64 DER
+      or whose ASN.1 structure cannot be parsed by `:public_key`.
+    * `:certificate_expired` — parseable certificate whose `notAfter` is in
+      the past relative to `DateTime.utc_now/0`. Silence-able via
+      `ExSaml.Metadata.validate/2`'s `:ignore` option.
+
+  Best-practice rules that depend on certificate inspection (CA detection,
+  KeyUsage linting, shared signing/encryption certificate) live in the next
+  batch of rules alongside strict-mode plumbing — see issue #17 PR 3.
+  """
 
   alias ExSaml.Metadata.ValidationResult
 

--- a/lib/ex_saml/metadata/certificate.ex
+++ b/lib/ex_saml/metadata/certificate.ex
@@ -1,0 +1,249 @@
+defmodule ExSaml.Metadata.Certificate do
+  @moduledoc false
+
+  # Certificate-level metadata validation rules.
+  #
+  # Iterates every `<md:KeyDescriptor>` declared under an `<md:SPSSODescriptor>`
+  # or `<md:IDPSSODescriptor>` and emits violations for the structural and
+  # validity expectations of PR 2:
+  #
+  #   * `:missing_x509_certificate` — KeyDescriptor without a non-empty
+  #     `<ds:X509Certificate>` text node.
+  #   * `:invalid_x509_certificate` — text that does not decode as base64 DER
+  #     or whose ASN.1 structure cannot be parsed by `:public_key`.
+  #   * `:certificate_expired` — parseable certificate whose `notAfter` is in
+  #     the past relative to `DateTime.utc_now/0`. Silence-able via
+  #     `ExSaml.Metadata.validate/2`'s `:ignore` option.
+  #
+  # Best-practice rules that depend on certificate inspection (CA detection,
+  # KeyUsage linting, shared signing/encryption certificate) live in the next
+  # batch of rules alongside strict-mode plumbing — see issue #17 PR 3.
+
+  alias ExSaml.Metadata.ValidationResult
+
+  require Record
+
+  Record.defrecordp(
+    :xml_element,
+    :xmlElement,
+    Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  Record.defrecordp(
+    :xml_text,
+    :xmlText,
+    Record.extract(:xmlText, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  @descriptor_kinds [:sp, :idp]
+
+  @spec violations(:xmerl.xmlElement(), keyword()) :: [ValidationResult.violation()]
+  def violations(root, namespaces) do
+    @descriptor_kinds
+    |> Enum.flat_map(&key_descriptors_with_path(root, &1, namespaces))
+    |> Enum.flat_map(fn {kd, path} -> kd_violations(kd, path, namespaces) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # KeyDescriptor enumeration
+  # ---------------------------------------------------------------------------
+
+  defp key_descriptors_with_path(root, kind, namespaces) do
+    descriptor_tag = descriptor_tag(kind)
+
+    root
+    |> xpath_elems("./md:#{descriptor_tag}", namespaces)
+    |> Enum.flat_map(fn desc ->
+      kds = xpath_elems(desc, "./md:KeyDescriptor", namespaces)
+      total = length(kds)
+
+      kds
+      |> Enum.with_index(1)
+      |> Enum.map(fn {kd, idx} ->
+        index_segment = if total > 1, do: "[#{idx}]", else: ""
+        {kd, "/EntityDescriptor/#{descriptor_tag}/KeyDescriptor#{index_segment}"}
+      end)
+    end)
+  end
+
+  defp descriptor_tag(:sp), do: "SPSSODescriptor"
+  defp descriptor_tag(:idp), do: "IDPSSODescriptor"
+
+  # ---------------------------------------------------------------------------
+  # Per-KeyDescriptor rules
+  # ---------------------------------------------------------------------------
+
+  defp kd_violations(kd, kd_path, namespaces) do
+    cert_elems = xpath_elems(kd, "./ds:KeyInfo/ds:X509Data/ds:X509Certificate", namespaces)
+
+    case cert_elems do
+      [] ->
+        [missing_cert_violation(kd_path)]
+
+      list ->
+        total = length(list)
+
+        list
+        |> Enum.with_index(1)
+        |> Enum.flat_map(fn {cert_elem, idx} ->
+          cert_path = cert_path(kd_path, idx, total)
+
+          case String.trim(text_content(cert_elem)) do
+            "" -> [missing_cert_violation(kd_path)]
+            text -> validate_cert(text, cert_path)
+          end
+        end)
+    end
+  end
+
+  defp cert_path(kd_path, _idx, 1), do: kd_path <> "/KeyInfo/X509Data/X509Certificate"
+  defp cert_path(kd_path, idx, _), do: kd_path <> "/KeyInfo/X509Data/X509Certificate[#{idx}]"
+
+  defp validate_cert(b64, path) do
+    case parse_b64(b64) do
+      {:ok, cert} ->
+        if expired?(cert, DateTime.utc_now()) do
+          [expired_violation(path)]
+        else
+          []
+        end
+
+      :error ->
+        [invalid_cert_violation(path)]
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Certificate parsing
+  # ---------------------------------------------------------------------------
+
+  defp parse_b64(b64) do
+    cleaned = String.replace(b64, ~r/\s+/, "")
+
+    with {:ok, der} <- Base.decode64(cleaned),
+         {:ok, cert} <- safe_pkix_decode(der) do
+      {:ok, cert}
+    else
+      _ -> :error
+    end
+  end
+
+  defp safe_pkix_decode(der) do
+    {:ok, :public_key.pkix_decode_cert(der, :otp)}
+  rescue
+    _ -> :error
+  catch
+    _, _ -> :error
+  end
+
+  defp expired?(cert, now) do
+    case not_after(cert) do
+      %DateTime{} = dt -> DateTime.compare(now, dt) == :gt
+      nil -> false
+    end
+  end
+
+  defp not_after(cert) do
+    cert
+    |> elem(1)
+    |> elem(5)
+    |> elem(2)
+    |> parse_asn1_time()
+  rescue
+    _ -> nil
+  end
+
+  defp parse_asn1_time({:utcTime, charlist}) do
+    case to_string(charlist) do
+      <<yy::binary-2, mm::binary-2, dd::binary-2, hh::binary-2, mi::binary-2, ss::binary-2,
+        "Z">> ->
+        yy_int = String.to_integer(yy)
+        year = if yy_int >= 50, do: 1900 + yy_int, else: 2000 + yy_int
+        to_datetime(year, mm, dd, hh, mi, ss)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_asn1_time({:generalTime, charlist}) do
+    case to_string(charlist) do
+      <<year::binary-4, mm::binary-2, dd::binary-2, hh::binary-2, mi::binary-2, ss::binary-2,
+        "Z">> ->
+        to_datetime(String.to_integer(year), mm, dd, hh, mi, ss)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_asn1_time(_), do: nil
+
+  defp to_datetime(year, mm, dd, hh, mi, ss) do
+    iso =
+      "#{pad4(year)}-#{mm}-#{dd}T#{hh}:#{mi}:#{ss}Z"
+
+    case DateTime.from_iso8601(iso) do
+      {:ok, dt, 0} -> dt
+      _ -> nil
+    end
+  end
+
+  defp pad4(year), do: year |> Integer.to_string() |> String.pad_leading(4, "0")
+
+  # ---------------------------------------------------------------------------
+  # Text extraction
+  # ---------------------------------------------------------------------------
+
+  defp text_content(element) do
+    element
+    |> xml_element(:content)
+    |> Enum.flat_map(fn
+      child when Record.is_record(child, :xmlText) -> [xml_text(child, :value)]
+      _ -> []
+    end)
+    |> IO.iodata_to_binary()
+  end
+
+  # ---------------------------------------------------------------------------
+  # XPath wrapper
+  # ---------------------------------------------------------------------------
+
+  defp xpath_elems(context, path, namespaces) do
+    :xmerl_xpath.string(to_charlist(path), context, [{:namespace, namespaces}])
+  end
+
+  # ---------------------------------------------------------------------------
+  # Violation builders
+  # ---------------------------------------------------------------------------
+
+  defp missing_cert_violation(kd_path) do
+    %{
+      code: :missing_x509_certificate,
+      severity: :error,
+      message: "<md:KeyDescriptor> must contain a non-empty <ds:X509Certificate>",
+      path: kd_path,
+      spec_reference: "SAML 2.0 Metadata §2.4.1.1, XML-DSig §4.4.4"
+    }
+  end
+
+  defp invalid_cert_violation(path) do
+    %{
+      code: :invalid_x509_certificate,
+      severity: :error,
+      message: "<ds:X509Certificate> content is not a parseable base64 DER X.509 certificate",
+      path: path,
+      spec_reference: "XML-DSig §4.4.4, RFC 5280 §4.1"
+    }
+  end
+
+  defp expired_violation(path) do
+    %{
+      code: :certificate_expired,
+      severity: :error,
+      message: "X.509 certificate is expired (notAfter is in the past)",
+      path: path,
+      spec_reference: "RFC 5280 §4.1.2.5"
+    }
+  end
+end

--- a/lib/ex_saml/metadata/certificate.ex
+++ b/lib/ex_saml/metadata/certificate.ex
@@ -19,8 +19,6 @@ defmodule ExSaml.Metadata.Certificate do
   batch of rules alongside strict-mode plumbing — see issue #17 PR 3.
   """
 
-  alias ExSaml.Metadata.ValidationResult
-
   require Record
 
   Record.defrecordp(
@@ -37,7 +35,6 @@ defmodule ExSaml.Metadata.Certificate do
 
   @descriptor_kinds [:sp, :idp]
 
-  @spec violations(:xmerl.xmlElement(), keyword()) :: [ValidationResult.violation()]
   def violations(root, namespaces) do
     @descriptor_kinds
     |> Enum.flat_map(&key_descriptors_with_path(root, &1, namespaces))

--- a/lib/ex_saml/metadata/certificate.ex
+++ b/lib/ex_saml/metadata/certificate.ex
@@ -53,17 +53,21 @@ defmodule ExSaml.Metadata.Certificate do
 
     root
     |> xpath_elems("./md:#{descriptor_tag}", namespaces)
-    |> Enum.flat_map(fn desc ->
-      kds = xpath_elems(desc, "./md:KeyDescriptor", namespaces)
-      total = length(kds)
+    |> Enum.flat_map(&kds_under_descriptor(&1, descriptor_tag, namespaces))
+  end
 
-      kds
-      |> Enum.with_index(1)
-      |> Enum.map(fn {kd, idx} ->
-        index_segment = if total > 1, do: "[#{idx}]", else: ""
-        {kd, "/EntityDescriptor/#{descriptor_tag}/KeyDescriptor#{index_segment}"}
-      end)
-    end)
+  defp kds_under_descriptor(desc, descriptor_tag, namespaces) do
+    kds = xpath_elems(desc, "./md:KeyDescriptor", namespaces)
+    total = length(kds)
+
+    kds
+    |> Enum.with_index(1)
+    |> Enum.map(&kd_with_path(&1, descriptor_tag, total))
+  end
+
+  defp kd_with_path({kd, idx}, descriptor_tag, total) do
+    index_segment = if total > 1, do: "[#{idx}]", else: ""
+    {kd, "/EntityDescriptor/#{descriptor_tag}/KeyDescriptor#{index_segment}"}
   end
 
   defp descriptor_tag(:sp), do: "SPSSODescriptor"
@@ -85,14 +89,16 @@ defmodule ExSaml.Metadata.Certificate do
 
         list
         |> Enum.with_index(1)
-        |> Enum.flat_map(fn {cert_elem, idx} ->
-          cert_path = cert_path(kd_path, idx, total)
+        |> Enum.flat_map(&cert_elem_violations(&1, kd_path, total))
+    end
+  end
 
-          case String.trim(text_content(cert_elem)) do
-            "" -> [missing_cert_violation(kd_path)]
-            text -> validate_cert(text, cert_path)
-          end
-        end)
+  defp cert_elem_violations({cert_elem, idx}, kd_path, total) do
+    cert_path = cert_path(kd_path, idx, total)
+
+    case String.trim(text_content(cert_elem)) do
+      "" -> [missing_cert_violation(kd_path)]
+      text -> validate_cert(text, cert_path)
     end
   end
 
@@ -155,8 +161,7 @@ defmodule ExSaml.Metadata.Certificate do
 
   defp parse_asn1_time({:utcTime, charlist}) do
     case to_string(charlist) do
-      <<yy::binary-2, mm::binary-2, dd::binary-2, hh::binary-2, mi::binary-2, ss::binary-2,
-        "Z">> ->
+      <<yy::binary-2, mm::binary-2, dd::binary-2, hh::binary-2, mi::binary-2, ss::binary-2, "Z">> ->
         yy_int = String.to_integer(yy)
         year = if yy_int >= 50, do: 1900 + yy_int, else: 2000 + yy_int
         to_datetime(year, mm, dd, hh, mi, ss)

--- a/lib/ex_saml/metadata/signature.ex
+++ b/lib/ex_saml/metadata/signature.ex
@@ -1,22 +1,22 @@
 defmodule ExSaml.Metadata.Signature do
-  @moduledoc false
+  @moduledoc """
+  Structural validation of `<ds:Signature>` elements declared inside SAML
+  metadata. Emits three always-error violations:
 
-  # Structural validation of `<ds:Signature>` elements declared inside SAML
-  # metadata. Emits three always-error violations:
-  #
-  #   * `:invalid_signature_structure` — a `<ds:Signature>` is present but
-  #     missing one of the mandatory XML-DSig children (`SignedInfo`,
-  #     `SignatureValue`, `SignedInfo/SignatureMethod`, `SignedInfo/Reference`,
-  #     `Reference/DigestMethod`, `Reference/DigestValue`).
-  #   * `:unknown_signature_algorithm` — `<ds:SignatureMethod Algorithm>` is
-  #     not in the XML-DSig / xmldsig-more spec-defined set. Deprecated but
-  #     spec-defined values (RSA-SHA1, etc.) are still recognized here; the
-  #     dedicated `:deprecated_signature_algorithm` rule ships with PR 3 and
-  #     its strict-mode promotion.
-  #   * `:unknown_digest_algorithm` — same idea for `<ds:DigestMethod>`.
-  #
-  # Cryptographic verification of the signature against a trust anchor is
-  # out of scope (see issue #17 "Non-goals").
+    * `:invalid_signature_structure` — a `<ds:Signature>` is present but
+      missing one of the mandatory XML-DSig children (`SignedInfo`,
+      `SignatureValue`, `SignedInfo/SignatureMethod`, `SignedInfo/Reference`,
+      `Reference/DigestMethod`, `Reference/DigestValue`).
+    * `:unknown_signature_algorithm` — `<ds:SignatureMethod Algorithm>` is
+      not in the XML-DSig / xmldsig-more spec-defined set. Deprecated but
+      spec-defined values (RSA-SHA1, etc.) are still recognized here; the
+      dedicated `:deprecated_signature_algorithm` rule ships with PR 3 and
+      its strict-mode promotion.
+    * `:unknown_digest_algorithm` — same idea for `<ds:DigestMethod>`.
+
+  Cryptographic verification of the signature against a trust anchor is
+  out of scope (see issue #17 "Non-goals").
+  """
 
   alias ExSaml.Metadata.ValidationResult
 

--- a/lib/ex_saml/metadata/signature.ex
+++ b/lib/ex_saml/metadata/signature.ex
@@ -1,0 +1,263 @@
+defmodule ExSaml.Metadata.Signature do
+  @moduledoc false
+
+  # Structural validation of `<ds:Signature>` elements declared inside SAML
+  # metadata. Emits three always-error violations:
+  #
+  #   * `:invalid_signature_structure` — a `<ds:Signature>` is present but
+  #     missing one of the mandatory XML-DSig children (`SignedInfo`,
+  #     `SignatureValue`, `SignedInfo/SignatureMethod`, `SignedInfo/Reference`,
+  #     `Reference/DigestMethod`, `Reference/DigestValue`).
+  #   * `:unknown_signature_algorithm` — `<ds:SignatureMethod Algorithm>` is
+  #     not in the XML-DSig / xmldsig-more spec-defined set. Deprecated but
+  #     spec-defined values (RSA-SHA1, etc.) are still recognized here; the
+  #     dedicated `:deprecated_signature_algorithm` rule ships with PR 3 and
+  #     its strict-mode promotion.
+  #   * `:unknown_digest_algorithm` — same idea for `<ds:DigestMethod>`.
+  #
+  # Cryptographic verification of the signature against a trust anchor is
+  # out of scope (see issue #17 "Non-goals").
+
+  alias ExSaml.Metadata.ValidationResult
+
+  require Record
+
+  Record.defrecordp(
+    :xml_element,
+    :xmlElement,
+    Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  Record.defrecordp(
+    :xml_attribute,
+    :xmlAttribute,
+    Record.extract(:xmlAttribute, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  # Spec-defined XML-DSig signature algorithm URIs (RFC 6931, RFC 4051,
+  # XML-DSig §6.4). Recognised by PR 2 regardless of cryptographic strength —
+  # PR 3 introduces the modern-only subset for :deprecated_signature_algorithm.
+  @known_signature_algorithms MapSet.new([
+                                "http://www.w3.org/2000/09/xmldsig#dsa-sha1",
+                                "http://www.w3.org/2000/09/xmldsig#rsa-sha1",
+                                "http://www.w3.org/2000/09/xmldsig#hmac-sha1",
+                                "http://www.w3.org/2001/04/xmldsig-more#rsa-md5",
+                                "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+                                "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384",
+                                "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512",
+                                "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256",
+                                "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384",
+                                "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512",
+                                "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1",
+                                "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224",
+                                "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+                                "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384",
+                                "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"
+                              ])
+
+  @known_digest_algorithms MapSet.new([
+                             "http://www.w3.org/2000/09/xmldsig#sha1",
+                             "http://www.w3.org/2001/04/xmldsig-more#md5",
+                             "http://www.w3.org/2001/04/xmlenc#sha256",
+                             "http://www.w3.org/2001/04/xmldsig-more#sha384",
+                             "http://www.w3.org/2001/04/xmlenc#sha512",
+                             "http://www.w3.org/2001/04/xmlenc#ripemd160"
+                           ])
+
+  @spec violations(:xmerl.xmlElement(), keyword()) :: [ValidationResult.violation()]
+  def violations(root, namespaces) do
+    root
+    |> signatures_with_path(namespaces)
+    |> Enum.flat_map(fn {sig, path} -> signature_violations(sig, path, namespaces) end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Signature discovery
+  # ---------------------------------------------------------------------------
+
+  defp signatures_with_path(root, namespaces) do
+    document_level = collect("/EntityDescriptor", root, "./ds:Signature", namespaces)
+
+    descriptor_level =
+      ["SPSSODescriptor", "IDPSSODescriptor"]
+      |> Enum.flat_map(fn tag ->
+        root
+        |> xpath_elems("./md:#{tag}", namespaces)
+        |> Enum.flat_map(fn desc ->
+          collect("/EntityDescriptor/#{tag}", desc, "./ds:Signature", namespaces)
+        end)
+      end)
+
+    document_level ++ descriptor_level
+  end
+
+  defp collect(parent_path, context, xpath, namespaces) do
+    sigs = xpath_elems(context, xpath, namespaces)
+    total = length(sigs)
+
+    sigs
+    |> Enum.with_index(1)
+    |> Enum.map(fn {sig, idx} ->
+      index_segment = if total > 1, do: "[#{idx}]", else: ""
+      {sig, "#{parent_path}/Signature#{index_segment}"}
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Per-signature rules
+  # ---------------------------------------------------------------------------
+
+  defp signature_violations(sig, sig_path, namespaces) do
+    case xpath_elems(sig, "./ds:SignedInfo", namespaces) do
+      [] ->
+        [missing_node(sig_path, "SignedInfo")]
+
+      [signed_info | _] ->
+        signature_value_violations(sig, sig_path, namespaces) ++
+          signed_info_violations(signed_info, sig_path, namespaces)
+    end
+  end
+
+  defp signature_value_violations(sig, sig_path, namespaces) do
+    case xpath_elems(sig, "./ds:SignatureValue", namespaces) do
+      [] -> [missing_node(sig_path, "SignatureValue")]
+      _ -> []
+    end
+  end
+
+  defp signed_info_violations(signed_info, sig_path, namespaces) do
+    signature_method_violations(signed_info, sig_path, namespaces) ++
+      reference_violations(signed_info, sig_path, namespaces)
+  end
+
+  defp signature_method_violations(signed_info, sig_path, namespaces) do
+    case xpath_elems(signed_info, "./ds:SignatureMethod", namespaces) do
+      [] ->
+        [missing_node(sig_path, "SignedInfo/SignatureMethod")]
+
+      [method | _] ->
+        algorithm_violation(
+          method,
+          "#{sig_path}/SignedInfo/SignatureMethod/@Algorithm",
+          @known_signature_algorithms,
+          :unknown_signature_algorithm,
+          "SignatureMethod"
+        )
+    end
+  end
+
+  defp reference_violations(signed_info, sig_path, namespaces) do
+    case xpath_elems(signed_info, "./ds:Reference", namespaces) do
+      [] ->
+        [missing_node(sig_path, "SignedInfo/Reference")]
+
+      refs ->
+        refs
+        |> Enum.with_index(1)
+        |> Enum.flat_map(fn {ref, idx} ->
+          ref_path = "#{sig_path}/SignedInfo/Reference[#{idx}]"
+          digest_method_violations(ref, ref_path, namespaces) ++
+            digest_value_violations(ref, ref_path, namespaces)
+        end)
+    end
+  end
+
+  defp digest_method_violations(ref, ref_path, namespaces) do
+    case xpath_elems(ref, "./ds:DigestMethod", namespaces) do
+      [] ->
+        [missing_signature_node(ref_path <> "/DigestMethod")]
+
+      [method | _] ->
+        algorithm_violation(
+          method,
+          "#{ref_path}/DigestMethod/@Algorithm",
+          @known_digest_algorithms,
+          :unknown_digest_algorithm,
+          "DigestMethod"
+        )
+    end
+  end
+
+  defp digest_value_violations(ref, ref_path, namespaces) do
+    case xpath_elems(ref, "./ds:DigestValue", namespaces) do
+      [] -> [missing_signature_node(ref_path <> "/DigestValue")]
+      _ -> []
+    end
+  end
+
+  defp algorithm_violation(element, path, known, code, kind) do
+    case attr_value(element, "Algorithm") do
+      nil ->
+        [
+          %{
+            code: :invalid_signature_structure,
+            severity: :error,
+            message: "<ds:#{kind}> is missing the required Algorithm attribute",
+            path: path,
+            spec_reference: "XML-DSig §4.3"
+          }
+        ]
+
+      value ->
+        if value in known do
+          []
+        else
+          [
+            %{
+              code: code,
+              severity: :error,
+              message: "Unknown #{kind} algorithm URI: " <> inspect(value),
+              path: path,
+              spec_reference: "XML-DSig §6.4, RFC 6931"
+            }
+          ]
+        end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Violation builders
+  # ---------------------------------------------------------------------------
+
+  defp missing_node(sig_path, child) do
+    %{
+      code: :invalid_signature_structure,
+      severity: :error,
+      message: "<ds:Signature> is missing required child <ds:#{child}>",
+      path: "#{sig_path}/#{child}",
+      spec_reference: "XML-DSig §4.3"
+    }
+  end
+
+  defp missing_signature_node(path) do
+    %{
+      code: :invalid_signature_structure,
+      severity: :error,
+      message: "<ds:Signature> is missing required descendant " <> path,
+      path: path,
+      spec_reference: "XML-DSig §4.3"
+    }
+  end
+
+  # ---------------------------------------------------------------------------
+  # XPath helpers
+  # ---------------------------------------------------------------------------
+
+  defp xpath_elems(context, path, namespaces) do
+    :xmerl_xpath.string(to_charlist(path), context, [{:namespace, namespaces}])
+  end
+
+  defp attr_value(element, name) do
+    case xpath_elems(element, "@#{name}", []) do
+      [attr] ->
+        if Record.is_record(attr, :xmlAttribute) do
+          attr |> xml_attribute(:value) |> to_string()
+        else
+          nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/ex_saml/metadata/signature.ex
+++ b/lib/ex_saml/metadata/signature.ex
@@ -18,8 +18,6 @@ defmodule ExSaml.Metadata.Signature do
   out of scope (see issue #17 "Non-goals").
   """
 
-  alias ExSaml.Metadata.ValidationResult
-
   require Record
 
   Record.defrecordp(
@@ -64,7 +62,6 @@ defmodule ExSaml.Metadata.Signature do
                              "http://www.w3.org/2001/04/xmlenc#ripemd160"
                            ])
 
-  @spec violations(:xmerl.xmlElement(), keyword()) :: [ValidationResult.violation()]
   def violations(root, namespaces) do
     root
     |> signatures_with_path(namespaces)

--- a/lib/ex_saml/metadata/signature.ex
+++ b/lib/ex_saml/metadata/signature.ex
@@ -156,6 +156,7 @@ defmodule ExSaml.Metadata.Signature do
         |> Enum.with_index(1)
         |> Enum.flat_map(fn {ref, idx} ->
           ref_path = "#{sig_path}/SignedInfo/Reference[#{idx}]"
+
           digest_method_violations(ref, ref_path, namespaces) ++
             digest_value_violations(ref, ref_path, namespaces)
         end)

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule ExSaml.MixProject do
       description: description(),
       dialyzer: [ignore_warnings: ".dialyzer_ignore.exs"],
       elixir: "~> 1.15",
+      elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       preferred_cli_env: preferred_cli_env(),
       source_url: @source_url,
@@ -20,6 +21,9 @@ defmodule ExSaml.MixProject do
       version: @version
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.
   def application do
@@ -42,7 +46,8 @@ defmodule ExSaml.MixProject do
       {:nebulex, "~> 2.6"},
       {:plug, "~> 1.18"},
       {:sobelow, "~> 0.13", only: [:dev, :test], runtime: false},
-      {:sweet_xml, "~> 0.7"}
+      {:sweet_xml, "~> 0.7"},
+      {:x509, "~> 0.9", only: [:test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -23,6 +23,7 @@
   "sobelow": {:hex, :sobelow, "0.14.1", "2f81e8632f15574cba2402bcddff5497b413c01e6f094bc0ab94e83c2f74db81", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8fac9a2bd90fdc4b15d6fca6e1608efb7f7c600fa75800813b794ee9364c87f2"},
   "sweet_xml": {:hex, :sweet_xml, "0.7.5", "803a563113981aaac202a1dbd39771562d0ad31004ddbfc9b5090bdcd5605277", [:mix], [], "hexpm", "193b28a9b12891cae351d81a0cead165ffe67df1b73fe5866d10629f4faefb12"},
   "telemetry": {:hex, :telemetry, "1.4.1", "ab6de178e2b29b58e8256b92b382ea3f590a47152ca3651ea857a6cae05ac423", [:rebar3], [], "hexpm", "2172e05a27531d3d31dd9782841065c50dd5c3c7699d95266b2edd54c2dafa1c"},
+  "x509": {:hex, :x509, "0.9.2", "a75aa605348abd905990f3d2dc1b155fcde4e030fa2f90c4a91534405dce0f6e", [:mix], [], "hexpm", "4c5ede75697e565d4b0f5be04c3b71bb1fd3a090ea243af4bd7dae144e48cfc7"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.12.1", "d74f2d82294651b58dac849c45a82aaea639766797359baff834b64439f6b3f4", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "d9ac16563c737d55f9bfeed7627489156b91268a3a21cd55c54eb2e335207fed"},
 }

--- a/test/ex_saml/metadata_test.exs
+++ b/test/ex_saml/metadata_test.exs
@@ -3,12 +3,41 @@ defmodule ExSaml.MetadataTest do
 
   alias ExSaml.Metadata
   alias ExSaml.Metadata.ValidationResult
+  alias ExSaml.Test.CertFactory
 
   @fixtures_dir Path.expand("../fixtures/metadata", __DIR__)
 
   defp read_fixture(name), do: File.read!(Path.join(@fixtures_dir, name))
 
   defp codes(violations), do: Enum.map(violations, & &1.code)
+
+  defp sp_metadata_with_keys(key_descriptors) do
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                         xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                         entityID="https://sp.example.com/saml">
+      <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        #{Enum.join(key_descriptors, "\n    ")}
+        <md:AssertionConsumerService index="0" isDefault="true"
+                                     Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                     Location="https://sp.example.com/saml/acs"/>
+      </md:SPSSODescriptor>
+    </md:EntityDescriptor>
+    """
+  end
+
+  defp key_descriptor(use, b64) do
+    """
+    <md:KeyDescriptor use="#{use}">
+          <ds:KeyInfo>
+            <ds:X509Data>
+              <ds:X509Certificate>#{b64}</ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </md:KeyDescriptor>
+    """
+  end
 
   describe "validate/1 happy path" do
     test "returns :ok on spec-clean SP metadata" do
@@ -217,6 +246,84 @@ defmodule ExSaml.MetadataTest do
 
       assert {:ok, %ValidationResult{errors: [], warnings: []}} =
                Metadata.validate(xml, ignore: [])
+    end
+  end
+
+  describe "certificate rules" do
+    test "flags <md:KeyDescriptor> without <ds:X509Certificate>" do
+      xml = read_fixture("keydescriptor_missing_cert.xml")
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :missing_x509_certificate in codes(errors)
+    end
+
+    test "flags <ds:X509Certificate> with non-base64 content" do
+      xml = read_fixture("keydescriptor_invalid_cert.xml")
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :invalid_x509_certificate in codes(errors)
+    end
+
+    test "flags base64 content that decodes but is not a valid X.509 cert" do
+      garbage_b64 = Base.encode64("hello world this is not a der cert")
+      xml = sp_metadata_with_keys([key_descriptor("signing", garbage_b64)])
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :invalid_x509_certificate in codes(errors)
+    end
+
+    test "accepts a spec-clean SP with a freshly-issued signing cert" do
+      cert = CertFactory.signing()
+      xml = sp_metadata_with_keys([key_descriptor("signing", cert.b64)])
+
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} = Metadata.validate(xml)
+    end
+
+    test "flags an expired signing cert with :certificate_expired" do
+      cert = CertFactory.expired()
+      xml = sp_metadata_with_keys([key_descriptor("signing", cert.b64)])
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :certificate_expired in codes(errors)
+
+      err = Enum.find(errors, &(&1.code == :certificate_expired))
+      assert err.path =~ "SPSSODescriptor/KeyDescriptor"
+      assert err.path =~ "X509Certificate"
+    end
+
+    test ":ignore silences :certificate_expired" do
+      cert = CertFactory.expired()
+      xml = sp_metadata_with_keys([key_descriptor("signing", cert.b64)])
+
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} =
+               Metadata.validate(xml, ignore: [:certificate_expired])
+    end
+
+    test "indexes paths when multiple KeyDescriptors are present" do
+      signing = CertFactory.signing()
+      encryption = CertFactory.encryption()
+      expired = CertFactory.expired()
+
+      xml =
+        sp_metadata_with_keys([
+          key_descriptor("signing", signing.b64),
+          key_descriptor("encryption", encryption.b64),
+          key_descriptor("signing", expired.b64)
+        ])
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+
+      err = Enum.find(errors, &(&1.code == :certificate_expired))
+      assert err
+      assert err.path =~ "KeyDescriptor[3]"
+    end
+
+    test "does not fire on metadata with no <md:KeyDescriptor>" do
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} =
+               Metadata.validate(read_fixture("sp_clean.xml"))
+
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} =
+               Metadata.validate(read_fixture("idp_clean.xml"))
     end
   end
 end

--- a/test/ex_saml/metadata_test.exs
+++ b/test/ex_saml/metadata_test.exs
@@ -326,4 +326,168 @@ defmodule ExSaml.MetadataTest do
                Metadata.validate(read_fixture("idp_clean.xml"))
     end
   end
+
+  describe "ds:Signature structural rules" do
+    @valid_sig """
+    <ds:Signature>
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>YWJjZGVm</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>YmFzZTY0c2lnbmF0dXJl</ds:SignatureValue>
+    </ds:Signature>
+    """
+
+    defp sp_metadata_with_signature(signature_xml) do
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                           xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                           entityID="https://sp.example.com/saml">
+        #{signature_xml}
+        <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+          <md:AssertionConsumerService index="0" isDefault="true"
+                                       Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                       Location="https://sp.example.com/saml/acs"/>
+        </md:SPSSODescriptor>
+      </md:EntityDescriptor>
+      """
+    end
+
+    test "accepts metadata with a structurally valid <ds:Signature>" do
+      xml = sp_metadata_with_signature(@valid_sig)
+
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} = Metadata.validate(xml)
+    end
+
+    test "flags <ds:Signature> without <ds:SignedInfo>" do
+      xml = read_fixture("signature_missing_signed_info.xml")
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :invalid_signature_structure in codes(errors)
+
+      err = Enum.find(errors, &(&1.code == :invalid_signature_structure))
+      assert err.path =~ "SignedInfo"
+    end
+
+    test "flags <ds:Signature> without <ds:SignatureValue>" do
+      sig = """
+      <ds:Signature>
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+          <ds:Reference URI="">
+            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+            <ds:DigestValue>YWJjZGVm</ds:DigestValue>
+          </ds:Reference>
+        </ds:SignedInfo>
+      </ds:Signature>
+      """
+
+      xml = sp_metadata_with_signature(sig)
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :invalid_signature_structure in codes(errors)
+      assert Enum.any?(errors, &(&1.path =~ "SignatureValue"))
+    end
+
+    test "flags a <ds:Reference> missing <ds:DigestValue>" do
+      sig = """
+      <ds:Signature>
+        <ds:SignedInfo>
+          <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+          <ds:Reference URI="">
+            <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>YmFzZTY0</ds:SignatureValue>
+      </ds:Signature>
+      """
+
+      xml = sp_metadata_with_signature(sig)
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+
+      err =
+        Enum.find(errors, fn e ->
+          e.code == :invalid_signature_structure and e.path =~ "Reference[1]/DigestValue"
+        end)
+
+      assert err
+    end
+
+    test "flags an unknown SignatureMethod algorithm" do
+      xml = read_fixture("signature_unknown_algorithm.xml")
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :unknown_signature_algorithm in codes(errors)
+
+      err = Enum.find(errors, &(&1.code == :unknown_signature_algorithm))
+      assert err.path =~ "SignatureMethod/@Algorithm"
+    end
+
+    test "flags an unknown DigestMethod algorithm" do
+      xml = read_fixture("signature_unknown_digest.xml")
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+      assert :unknown_digest_algorithm in codes(errors)
+
+      err = Enum.find(errors, &(&1.code == :unknown_digest_algorithm))
+      assert err.path =~ "Reference[1]/DigestMethod/@Algorithm"
+    end
+
+    test "recognises RSA-SHA1 as a known (legacy) signature algorithm" do
+      sig =
+        String.replace(
+          @valid_sig,
+          "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+          "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+        )
+
+      xml = sp_metadata_with_signature(sig)
+
+      # PR 2 only checks "known" — RSA-SHA1 stays valid here.
+      # PR 3 introduces :deprecated_signature_algorithm to flag it.
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} = Metadata.validate(xml)
+    end
+
+    test ":ignore silences :unknown_signature_algorithm" do
+      xml = read_fixture("signature_unknown_algorithm.xml")
+
+      assert {:ok, %ValidationResult{errors: [], warnings: []}} =
+               Metadata.validate(xml, ignore: [:unknown_signature_algorithm])
+    end
+
+    test "detects a <ds:Signature> nested inside a descriptor" do
+      xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                           xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                           entityID="https://sp.example.com/saml">
+        <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+          <ds:Signature>
+            <ds:SignatureValue>YmFzZTY0</ds:SignatureValue>
+          </ds:Signature>
+          <md:AssertionConsumerService index="0" isDefault="true"
+                                       Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                       Location="https://sp.example.com/saml/acs"/>
+        </md:SPSSODescriptor>
+      </md:EntityDescriptor>
+      """
+
+      assert {:error, %ValidationResult{errors: errors}} = Metadata.validate(xml)
+
+      err = Enum.find(errors, &(&1.code == :invalid_signature_structure))
+      assert err
+      assert err.path =~ "SPSSODescriptor/Signature/SignedInfo"
+    end
+  end
 end

--- a/test/fixtures/metadata/keydescriptor_invalid_cert.xml
+++ b/test/fixtures/metadata/keydescriptor_invalid_cert.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     entityID="https://sp.example.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>not-a-real-certificate!!</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:AssertionConsumerService index="0" isDefault="true"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                 Location="https://sp.example.com/saml/acs"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/fixtures/metadata/keydescriptor_missing_cert.xml
+++ b/test/fixtures/metadata/keydescriptor_missing_cert.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     entityID="https://sp.example.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data/>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:AssertionConsumerService index="0" isDefault="true"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                 Location="https://sp.example.com/saml/acs"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/fixtures/metadata/signature_missing_signed_info.xml
+++ b/test/fixtures/metadata/signature_missing_signed_info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     entityID="https://sp.example.com/saml">
+  <ds:Signature>
+    <ds:SignatureValue>YmFzZTY0c2lnbmF0dXJl</ds:SignatureValue>
+  </ds:Signature>
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:AssertionConsumerService index="0" isDefault="true"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                 Location="https://sp.example.com/saml/acs"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/fixtures/metadata/signature_unknown_algorithm.xml
+++ b/test/fixtures/metadata/signature_unknown_algorithm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     entityID="https://sp.example.com/saml">
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="urn:fake:made-up-signature-algorithm"/>
+      <ds:Reference URI="">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>YWJjZGVm</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>YmFzZTY0c2lnbmF0dXJl</ds:SignatureValue>
+  </ds:Signature>
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:AssertionConsumerService index="0" isDefault="true"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                 Location="https://sp.example.com/saml/acs"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/fixtures/metadata/signature_unknown_digest.xml
+++ b/test/fixtures/metadata/signature_unknown_digest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                     entityID="https://sp.example.com/saml">
+  <ds:Signature>
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="urn:fake:made-up-digest-algorithm"/>
+        <ds:DigestValue>YWJjZGVm</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>YmFzZTY0c2lnbmF0dXJl</ds:SignatureValue>
+  </ds:Signature>
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:AssertionConsumerService index="0" isDefault="true"
+                                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                 Location="https://sp.example.com/saml/acs"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/support/cert_factory.ex
+++ b/test/support/cert_factory.ex
@@ -1,0 +1,135 @@
+defmodule ExSaml.Test.CertFactory do
+  @moduledoc """
+  Test-only helper for generating self-signed X.509 certificates used in
+  `ExSaml.Metadata` validation tests.
+
+  Wraps the `X509` hex package with SAML-flavoured defaults. Every `build/1`
+  call produces a fresh 2048-bit RSA key and a matching self-signed
+  certificate with a 10-year validity window.
+
+  Returns a map with three views of the same cert:
+
+    * `:der`  — raw DER bytes
+    * `:pem`  — PEM-encoded binary
+    * `:b64`  — base64 DER, suitable for embedding in `<ds:X509Certificate>`
+  """
+
+  @type cert :: %{der: binary(), pem: binary(), b64: binary()}
+
+  @default_subject "/CN=ex_saml-test"
+  @default_key_size 2048
+  @default_validity_days 3650
+
+  @spec build(keyword()) :: cert()
+  def build(opts \\ []) do
+    subject = Keyword.get(opts, :subject, @default_subject)
+    key_size = Keyword.get(opts, :key_size, @default_key_size)
+    template = Keyword.get(opts, :template, :server)
+    extensions = Keyword.get(opts, :extensions, [])
+    validity = validity_from(opts)
+
+    key = X509.PrivateKey.new_rsa(key_size)
+
+    cert =
+      X509.Certificate.self_signed(key, subject,
+        template: template,
+        validity: validity,
+        extensions: extensions,
+        hash: :sha256
+      )
+
+    der = X509.Certificate.to_der(cert)
+    pem = X509.Certificate.to_pem(cert)
+
+    %{der: der, pem: pem, b64: Base.encode64(der)}
+  end
+
+  # -----
+  # Shorthand builders for common fixtures
+  # -----
+
+  @doc "Self-signed leaf cert with digitalSignature + keyEncipherment key usage."
+  @spec signing(keyword()) :: cert()
+  def signing(opts \\ []) do
+    build(
+      Keyword.merge(
+        [
+          template: :server,
+          extensions: [
+            basic_constraints: X509.Certificate.Extension.basic_constraints(false),
+            key_usage:
+              X509.Certificate.Extension.key_usage([:digitalSignature, :keyEncipherment])
+          ]
+        ],
+        opts
+      )
+    )
+  end
+
+  @doc "Self-signed leaf cert intended for encryption only (no digitalSignature)."
+  @spec encryption(keyword()) :: cert()
+  def encryption(opts \\ []) do
+    build(
+      Keyword.merge(
+        [
+          template: :server,
+          extensions: [
+            basic_constraints: X509.Certificate.Extension.basic_constraints(false),
+            key_usage: X509.Certificate.Extension.key_usage([:keyEncipherment])
+          ]
+        ],
+        opts
+      )
+    )
+  end
+
+  @doc "CA certificate (BasicConstraints CA:TRUE, KeyUsage includes keyCertSign)."
+  @spec ca(keyword()) :: cert()
+  def ca(opts \\ []) do
+    build(
+      Keyword.merge(
+        [
+          template: :root_ca,
+          extensions: [
+            basic_constraints: X509.Certificate.Extension.basic_constraints(true),
+            key_usage:
+              X509.Certificate.Extension.key_usage([
+                :digitalSignature,
+                :keyCertSign,
+                :cRLSign
+              ])
+          ]
+        ],
+        opts
+      )
+    )
+  end
+
+  @doc "Already-expired leaf cert (notAfter 1 day ago, notBefore 30 days ago)."
+  @spec expired(keyword()) :: cert()
+  def expired(opts \\ []) do
+    signing(Keyword.put(opts, :validity, expired_validity()))
+  end
+
+  # -----
+  # Internals
+  # -----
+
+  defp validity_from(opts) do
+    case Keyword.fetch(opts, :validity) do
+      {:ok, v} ->
+        v
+
+      :error ->
+        X509.Certificate.Validity.days_from_now(
+          Keyword.get(opts, :validity_days, @default_validity_days)
+        )
+    end
+  end
+
+  defp expired_validity do
+    not_before = DateTime.add(DateTime.utc_now(), -30 * 86_400, :second)
+    not_after = DateTime.add(DateTime.utc_now(), -1 * 86_400, :second)
+    X509.Certificate.Validity.new(not_before, not_after)
+  end
+end

--- a/test/support/cert_factory.ex
+++ b/test/support/cert_factory.ex
@@ -14,6 +14,11 @@ defmodule ExSaml.Test.CertFactory do
     * `:b64`  — base64 DER, suitable for embedding in `<ds:X509Certificate>`
   """
 
+  alias X509.Certificate
+  alias X509.Certificate.Extension
+  alias X509.Certificate.Validity
+  alias X509.PrivateKey
+
   @type cert :: %{der: binary(), pem: binary(), b64: binary()}
 
   @default_subject "/CN=ex_saml-test"
@@ -28,18 +33,18 @@ defmodule ExSaml.Test.CertFactory do
     extensions = Keyword.get(opts, :extensions, [])
     validity = validity_from(opts)
 
-    key = X509.PrivateKey.new_rsa(key_size)
+    key = PrivateKey.new_rsa(key_size)
 
     cert =
-      X509.Certificate.self_signed(key, subject,
+      Certificate.self_signed(key, subject,
         template: template,
         validity: validity,
         extensions: extensions,
         hash: :sha256
       )
 
-    der = X509.Certificate.to_der(cert)
-    pem = X509.Certificate.to_pem(cert)
+    der = Certificate.to_der(cert)
+    pem = Certificate.to_pem(cert)
 
     %{der: der, pem: pem, b64: Base.encode64(der)}
   end
@@ -56,9 +61,8 @@ defmodule ExSaml.Test.CertFactory do
         [
           template: :server,
           extensions: [
-            basic_constraints: X509.Certificate.Extension.basic_constraints(false),
-            key_usage:
-              X509.Certificate.Extension.key_usage([:digitalSignature, :keyEncipherment])
+            basic_constraints: Extension.basic_constraints(false),
+            key_usage: Extension.key_usage([:digitalSignature, :keyEncipherment])
           ]
         ],
         opts
@@ -74,8 +78,8 @@ defmodule ExSaml.Test.CertFactory do
         [
           template: :server,
           extensions: [
-            basic_constraints: X509.Certificate.Extension.basic_constraints(false),
-            key_usage: X509.Certificate.Extension.key_usage([:keyEncipherment])
+            basic_constraints: Extension.basic_constraints(false),
+            key_usage: Extension.key_usage([:keyEncipherment])
           ]
         ],
         opts
@@ -91,9 +95,9 @@ defmodule ExSaml.Test.CertFactory do
         [
           template: :root_ca,
           extensions: [
-            basic_constraints: X509.Certificate.Extension.basic_constraints(true),
+            basic_constraints: Extension.basic_constraints(true),
             key_usage:
-              X509.Certificate.Extension.key_usage([
+              Extension.key_usage([
                 :digitalSignature,
                 :keyCertSign,
                 :cRLSign
@@ -121,15 +125,13 @@ defmodule ExSaml.Test.CertFactory do
         v
 
       :error ->
-        X509.Certificate.Validity.days_from_now(
-          Keyword.get(opts, :validity_days, @default_validity_days)
-        )
+        Validity.days_from_now(Keyword.get(opts, :validity_days, @default_validity_days))
     end
   end
 
   defp expired_validity do
     not_before = DateTime.add(DateTime.utc_now(), -30 * 86_400, :second)
     not_after = DateTime.add(DateTime.utc_now(), -1 * 86_400, :second)
-    X509.Certificate.Validity.new(not_before, not_after)
+    Validity.new(not_before, not_after)
   end
 end


### PR DESCRIPTION
## Summary

Second slice of the metadata-validation effort tracked in #17 (PR 2 of the PLAN).

- Introduces `ExSaml.Metadata.Certificate`, plugged into the `run_rules/1` pipeline, which inspects every `<md:KeyDescriptor>` declared under SPSSO/IDPSSO descriptors and emits three always-error violations: `:missing_x509_certificate`, `:invalid_x509_certificate`, `:certificate_expired` (silence-able via `:ignore` for legacy scenarios).
- Introduces `ExSaml.Metadata.Signature`, also plugged into `run_rules/1`, which inspects every `<ds:Signature>` declared at document level or nested in a descriptor. Three always-error violations: `:invalid_signature_structure`, `:unknown_signature_algorithm`, `:unknown_digest_algorithm`.
- The signature-algorithm allow-list intentionally still recognises legacy URIs (RSA-SHA1, MD5, DSA-SHA1) — PR 2 only validates that an algorithm URI is part of the published XML-DSig / xmldsig-more set. The dedicated `:deprecated_signature_algorithm` rule that flags legacy URIs ships in PR 3 alongside strict-mode promotion.
- No new runtime dependency — `:public_key` is already in `extra_applications`. `:x509` is added as a test-only dependency to back the new `ExSaml.Test.CertFactory` helper, which generates self-signed signing / encryption / CA / expired certificates for the validation tests.

Cryptographic verification of `<ds:Signature>` against a trust anchor remains explicitly out of scope (see #17 "Non-goals").

### Decisions made during implementation

- **Cert-linting rules deferred to PR 3.** The issue PLAN explicitly leaves `:ca_certificate_used_for_signing`, `:invalid_signing_key_usage`, and `:shared_signing_and_encryption_certificate` open between PR 2 and PR 3. They live more naturally in PR 3 alongside the `:strict` plumbing and the warning→error promotion mechanism, so PR 2 stays focused on always-error rules.
- **Module split.** `lib/ex_saml/metadata.ex` orchestrates only; `Certificate` and `Signature` live as sibling modules and expose a single `violations(root, namespaces) :: [violation()]` entry point each. PR 3 will reuse `Certificate` helpers for the CA / KeyUsage / shared-cert rules and the `@known_signature_algorithms` set for the deprecated-algorithm rule.
- **Path conventions.** Each violation reports an XPath-like `:path`. Nodes that may repeat under a single parent (`KeyDescriptor`, `X509Certificate`, `Signature`, `Reference`) are indexed with 1-based `[N]` only when more than one is present — consistent with the `AssertionConsumerService[N]` convention introduced in PR 1.

### Out of scope for this PR

- Cert linting (CA detection, KeyUsage, shared signing/encryption cert) and the `:deprecated_signature_algorithm` rule — PR 3.
- Best-practice rules + strict mode + `:allow_http_endpoints`, `:cert_min_remaining_days` — PR 3.
- `:entity_id_domain_check` opt-in — PR 4.
- Documentation (README + ExDoc violation table) — PR 5.
- Cryptographic XML signature verification against a trust anchor — separate effort (`ExSaml.Metadata.verify_signature/2`).

## Test plan

- [x] `mix test` — 220/220 passing (16 new tests: 7 cert + 9 signature in `test/ex_saml/metadata_test.exs`).
- [x] `mix format --check-formatted` — clean.
- [x] `mix credo --strict` — no issues.
- [x] `mix deps.unlock --check-unused` — clean.
- [ ] CI green on GitHub Actions.

Refs #17 (PR 2 of 5).