### PR TITLE
📝 Docs / Sync migration guide & changelog with 1.1.1 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unused routes and pre-session create pipeline from Samly
 - Hardcoded Nebulex cache — replaced with delegate pattern
 
+[1.1.1]: https://github.com/docJerem/ex_saml/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/docJerem/ex_saml/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/docJerem/ex_saml/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/docJerem/ex_saml/compare/v1.0.0...v1.0.1

--- a/guides/migrating_from_samly.md
+++ b/guides/migrating_from_samly.md
@@ -146,8 +146,11 @@ Samly allowed a custom Plug pipeline to run before storing the assertion:
 ExSaml's `SPHandler.consume_signin_response/2` now returns a structured result instead:
 
 ```elixir
-{:ok, %{assertion: assertion, nonce: nonce, user_token: token, redirect_uri: uri}}
+{:ok, %{flow: flow, assertion: assertion, nonce: nonce, user_token: token, redirect_uri: uri}}
 ```
+
+`flow` is `:sp_initiated` or `:idp_initiated` (with `nonce` being `nil` for the
+IdP-initiated case, since no AuthnRequest — and therefore no nonce — exists).
 
 Move your custom assertion processing logic to the code that calls `consume_signin_response/2`.
 


### PR DESCRIPTION
## What

Bring the docs in line with the v1.1.1 changelog entries.

- **Migration guide** — `consume_signin_response/2`'s documented return shape was stale. Added the `flow:` field and a note on its values, matching the source `@doc` and the actual 1.1.1 behaviour:
  ```elixir
  {:ok, %{flow: flow, assertion: assertion, nonce: nonce, user_token: token, redirect_uri: uri}}
  ```
- **CHANGELOG** — the `[1.1.1]` heading had no compare-link reference at the bottom (the list stopped at `1.1.0`), so the version heading wasn't linked like the others. Added the missing reference.

## Notes

- The generated ExDoc output under `doc/` was also rebuilt locally (`mix docs`) to reflect 1.1.1 — the `flow:` field and the renamed `:idp_initiated_not_allowed` atom — but `doc/` is gitignored, so it's not part of this PR.
- `README.md` was reviewed and left unchanged: none of the 1.1.1 changes touch its documented surface (the IdP-initiated flow is already listed as supported; the return shape and error atoms aren't documented there).