### PR TITLE
Add HTTP-Redirect binding single-logout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/ex_saml.svg)](https://hex.pm/packages/ex_saml)
 [![Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/ex_saml)
 
+> **This is the artis-co-ltd fork of [docJerem/ex_saml](https://github.com/docJerem/ex_saml).**
+> The `redirect-binding-slo` branch adds, on top of v1.1.2, single-logout
+> support over the HTTP-Redirect binding (as sent by Microsoft Entra ID):
+>
+> - `GET /logout/:idp_id` route (the HTTP-POST binding route is unchanged)
+> - Mandatory query-string signature verification (SigAlg/Signature, SAML 2.0
+>   Bindings §3.4.4.1) of Redirect-binding LogoutRequests against the IdP
+>   metadata certificates — modelled after ruby-saml's
+>   `Utils.verify_signature` / `build_query_from_raw_parts`
+> - `InResponseTo` on generated LogoutResponses
+>
+> The changes are self-contained and intended to be proposed upstream.
+
 SAML 2.0 Service Provider (SP) library for Elixir/Phoenix applications.
 
 Originally built from the [Samly](https://hex.pm/packages/samly) codebase (by [handnot2](https://github.com/handnot2/samly)), before the [Dropbox fork](https://github.com/dropbox/samly) was created. Dropbox's fork has since been [declared unmaintained](https://github.com/dropbox/samly/pull/23#issuecomment-2537921498). ExSaml is the actively maintained successor, with enhanced security, configurable caching, and streamlined routing.

--- a/lib/ex_saml/core/logout_request.ex
+++ b/lib/ex_saml/core/logout_request.ex
@@ -5,7 +5,8 @@ defmodule ExSaml.Core.LogoutRequest do
   Ported from the Erlang `esaml_logoutreq` record.
   """
 
-  defstruct version: "2.0",
+  defstruct id: "",
+            version: "2.0",
             issue_instant: "",
             destination: "",
             issuer: "",
@@ -17,6 +18,7 @@ defmodule ExSaml.Core.LogoutRequest do
             reason: :user
 
   @type t :: %__MODULE__{
+          id: String.t(),
           version: String.t(),
           issue_instant: String.t(),
           destination: String.t(),

--- a/lib/ex_saml/core/logout_response.ex
+++ b/lib/ex_saml/core/logout_response.ex
@@ -6,6 +6,7 @@ defmodule ExSaml.Core.LogoutResponse do
   """
 
   defstruct version: "2.0",
+            in_response_to: "",
             issue_instant: "",
             destination: "",
             issuer: "",
@@ -13,6 +14,7 @@ defmodule ExSaml.Core.LogoutResponse do
 
   @type t :: %__MODULE__{
           version: String.t(),
+          in_response_to: String.t(),
           issue_instant: String.t(),
           destination: String.t(),
           issuer: String.t(),

--- a/lib/ex_saml/core/redirect_binding_signature.ex
+++ b/lib/ex_saml/core/redirect_binding_signature.ex
@@ -1,0 +1,169 @@
+defmodule ExSaml.Core.RedirectBindingSignature do
+  @moduledoc """
+  Verifies the query-string signature of a SAML HTTP-Redirect binding message.
+
+  Per SAML 2.0 Bindings §3.4.4.1 (DEFLATE encoding), a signed Redirect binding
+  message carries no XML signature. Instead, the sender signs the concatenation
+  of the URL-encoded query components, in this exact order:
+
+      SAMLRequest=value&RelayState=value&SigAlg=value
+
+  (`SAMLResponse` instead of `SAMLRequest` for responses; `RelayState` is
+  omitted when not present.) The Base64 signature is transmitted in the
+  `Signature` query parameter.
+
+  Verification MUST be performed against the *raw* (still URL-encoded) values
+  as they appeared on the wire: re-encoding decoded values may not reproduce
+  the original encoding (upper/lower case hex digits, space encoding, etc.).
+  This mirrors `OneLogin::RubySaml::Utils.build_query_from_raw_parts` /
+  `verify_signature` in ruby-saml.
+  """
+
+  require Record
+
+  Record.defrecord(
+    :otp_certificate,
+    :OTPCertificate,
+    Record.extract(:OTPCertificate, from_lib: "public_key/include/public_key.hrl")
+  )
+
+  Record.defrecord(
+    :otp_tbs_certificate,
+    :OTPTBSCertificate,
+    Record.extract(:OTPTBSCertificate, from_lib: "public_key/include/public_key.hrl")
+  )
+
+  Record.defrecord(
+    :otp_subject_public_key_info,
+    :OTPSubjectPublicKeyInfo,
+    Record.extract(:OTPSubjectPublicKeyInfo, from_lib: "public_key/include/public_key.hrl")
+  )
+
+  @digest_for_sig_alg %{
+    "http://www.w3.org/2000/09/xmldsig#rsa-sha1" => :sha,
+    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" => :sha256,
+    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384" => :sha384,
+    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512" => :sha512
+  }
+
+  @doc """
+  Verifies the Redirect binding signature carried in `query_string` against
+  the given IdP DER certificates (`ExSaml.IdpData.certs`).
+
+  `query_string` must be the raw query string as received on the wire
+  (`Plug.Conn.query_string/0`), NOT decoded parameters.
+
+  Verification succeeds if any one of the certificates validates the
+  signature, so that IdP signing-certificate rotation (old and new
+  certificates published side by side in metadata) keeps working.
+
+  Returns `:ok` or:
+
+    * `{:error, :missing_signature}` - `Signature` or `SigAlg` parameter absent,
+      or no `SAMLRequest`/`SAMLResponse` payload present
+    * `{:error, :unsupported_sig_alg}` - unknown `SigAlg` URI
+    * `{:error, :invalid_signature}` - malformed Base64 signature, or the
+      signature does not verify against any of the certificates
+  """
+  @spec verify(binary(), [binary()]) ::
+          :ok | {:error, :missing_signature | :unsupported_sig_alg | :invalid_signature}
+  def verify(query_string, der_certs) when is_binary(query_string) and is_list(der_certs) do
+    raw = raw_params(query_string)
+
+    with {:ok, sig_alg_raw, signature_raw} <- fetch_signature_params(raw),
+         {:ok, digest} <- digest_for(sig_alg_raw),
+         {:ok, signature} <- decode_signature(signature_raw),
+         {:ok, signed_data} <- build_signed_data(raw, sig_alg_raw) do
+      verify_with_certs(signed_data, digest, signature, der_certs)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Raw query parsing
+  # ---------------------------------------------------------------------------
+
+  # Splits the raw query string into a `%{name => raw_value}` map without
+  # decoding the values (parameter names are plain ASCII in this binding).
+  defp raw_params(query_string) do
+    query_string
+    |> String.split("&")
+    |> Enum.reduce(%{}, fn pair, acc ->
+      case String.split(pair, "=", parts: 2) do
+        [name, raw_value] -> Map.put_new(acc, name, raw_value)
+        _ -> acc
+      end
+    end)
+  end
+
+  defp fetch_signature_params(%{"SigAlg" => sig_alg, "Signature" => signature}),
+    do: {:ok, sig_alg, signature}
+
+  defp fetch_signature_params(_), do: {:error, :missing_signature}
+
+  defp digest_for(sig_alg_raw) do
+    case Map.fetch(@digest_for_sig_alg, safe_decode(sig_alg_raw)) do
+      {:ok, digest} -> {:ok, digest}
+      :error -> {:error, :unsupported_sig_alg}
+    end
+  end
+
+  defp decode_signature(signature_raw) do
+    case signature_raw |> safe_decode() |> Base.decode64(ignore: :whitespace) do
+      {:ok, signature} -> {:ok, signature}
+      :error -> {:error, :invalid_signature}
+    end
+  end
+
+  # Rebuilds the signed data in the canonical parameter order mandated by
+  # SAML 2.0 Bindings §3.4.4.1, from the raw (still URL-encoded) values.
+  defp build_signed_data(raw, sig_alg_raw) do
+    case Map.take(raw, ["SAMLRequest", "SAMLResponse"]) do
+      map when map_size(map) == 1 ->
+        [{type, payload}] = Map.to_list(map)
+
+        relay_state_part =
+          case raw do
+            %{"RelayState" => relay_state} -> "&RelayState=#{relay_state}"
+            _ -> ""
+          end
+
+        {:ok, "#{type}=#{payload}#{relay_state_part}&SigAlg=#{sig_alg_raw}"}
+
+      _ ->
+        {:error, :missing_signature}
+    end
+  end
+
+  defp safe_decode(raw_value) do
+    URI.decode_www_form(raw_value)
+  rescue
+    ArgumentError -> raw_value
+  end
+
+  # ---------------------------------------------------------------------------
+  # Public-key verification
+  # ---------------------------------------------------------------------------
+
+  defp verify_with_certs(signed_data, digest, signature, der_certs) do
+    der_certs
+    |> Enum.flat_map(&decode_public_key/1)
+    |> Enum.any?(&:public_key.verify(signed_data, digest, signature, &1))
+    |> case do
+      true -> :ok
+      false -> {:error, :invalid_signature}
+    end
+  end
+
+  defp decode_public_key(der_cert) do
+    der_cert
+    |> :public_key.pkix_decode_cert(:otp)
+    |> otp_certificate(:tbsCertificate)
+    |> otp_tbs_certificate(:subjectPublicKeyInfo)
+    |> otp_subject_public_key_info(:subjectPublicKey)
+    |> List.wrap()
+  rescue
+    # An undecodable certificate cannot validate anything; skip it so the
+    # remaining metadata certificates still get a chance.
+    _ -> []
+  end
+end

--- a/lib/ex_saml/core/saml.ex
+++ b/lib/ex_saml/core/saml.ex
@@ -466,8 +466,15 @@ defmodule ExSaml.Core.Saml do
           :not_found -> ""
         end
 
+      id =
+        case xpath_attr(xml, "/samlp:LogoutRequest/@ID", ns) do
+          {:ok, v} -> v
+          :not_found -> ""
+        end
+
       {:ok,
        %LogoutRequest{
+         id: id,
          version: version,
          issue_instant: issue_instant,
          name: name,
@@ -1016,6 +1023,7 @@ defmodule ExSaml.Core.Saml do
 
   def to_xml(%LogoutResponse{
         version: v,
+        in_response_to: in_response_to,
         issue_instant: time,
         destination: dest,
         issuer: issuer,
@@ -1029,16 +1037,22 @@ defmodule ExSaml.Core.Saml do
         ]
       )
 
+    in_response_to_attrs =
+      if in_response_to in [nil, ""],
+        do: [],
+        else: maybe_string_attr(:InResponseTo, in_response_to)
+
     elem =
       xmlElement(
         name: :"samlp:LogoutResponse",
-        attributes: [
-          xmlAttribute(name: :"xmlns:samlp", value: ~c"urn:oasis:names:tc:SAML:2.0:protocol"),
-          xmlAttribute(name: :"xmlns:saml", value: ~c"urn:oasis:names:tc:SAML:2.0:assertion"),
-          xmlAttribute(name: :IssueInstant, value: time),
-          xmlAttribute(name: :Version, value: v),
-          xmlAttribute(name: :Destination, value: dest)
-        ],
+        attributes:
+          [
+            xmlAttribute(name: :"xmlns:samlp", value: ~c"urn:oasis:names:tc:SAML:2.0:protocol"),
+            xmlAttribute(name: :"xmlns:saml", value: ~c"urn:oasis:names:tc:SAML:2.0:assertion"),
+            xmlAttribute(name: :IssueInstant, value: time),
+            xmlAttribute(name: :Version, value: v),
+            xmlAttribute(name: :Destination, value: dest)
+          ] ++ in_response_to_attrs,
         content: [
           xmlElement(
             name: :"saml:Issuer",

--- a/lib/ex_saml/core/sp.ex
+++ b/lib/ex_saml/core/sp.ex
@@ -168,14 +168,18 @@ defmodule ExSaml.Core.Sp do
 
   @doc """
   Generates a LogoutResponse XML element.
+
+  `in_response_to` is the `ID` of the LogoutRequest being answered; it is
+  emitted as the `InResponseTo` attribute and omitted when empty.
   """
-  @spec generate_logout_response(String.t(), atom(), SpConfig.t()) :: xml()
-  def generate_logout_response(idp_url, status, %SpConfig{} = sp) do
+  @spec generate_logout_response(String.t(), atom(), SpConfig.t(), String.t()) :: xml()
+  def generate_logout_response(idp_url, status, %SpConfig{} = sp, in_response_to \\ "") do
     stamp = now_saml_stamp()
     issuer = get_entity_id(sp)
 
     xml =
       Saml.to_xml(%LogoutResponse{
+        in_response_to: in_response_to,
         issue_instant: stamp,
         destination: idp_url,
         issuer: issuer,

--- a/lib/ex_saml/helper.ex
+++ b/lib/ex_saml/helper.ex
@@ -61,9 +61,12 @@ defmodule ExSaml.Helper do
     {idp_signout_url, xml_frag}
   end
 
-  def gen_idp_signout_resp(sp, idp_metadata, signout_status) do
+  def gen_idp_signout_resp(sp, idp_metadata, signout_status, in_response_to \\ "") do
     idp_signout_url = idp_metadata.logout_location
-    xml_frag = Core.Sp.generate_logout_response(idp_signout_url, signout_status, sp)
+
+    xml_frag =
+      Core.Sp.generate_logout_response(idp_signout_url, signout_status, sp, in_response_to)
+
     {idp_signout_url, xml_frag}
   end
 

--- a/lib/ex_saml/routers/sp_router.ex
+++ b/lib/ex_saml/routers/sp_router.ex
@@ -6,6 +6,10 @@ defmodule ExSaml.SPRouter do
   import Plug.Conn
 
   plug(:fetch_session)
+  # Redirect binding messages (GET /logout) arrive in the query string;
+  # Plug.Router does not fetch query params on its own. No-op when the host
+  # framework already fetched them.
+  plug(:fetch_query_params)
   plug(:match)
   plug(:check_idp_id)
   plug(:dispatch)
@@ -15,6 +19,17 @@ defmodule ExSaml.SPRouter do
   post("/consume/:idp_id", do: ExSaml.SPHandler.consume_signin_response(conn))
 
   post "/logout/:idp_id" do
+    cond do
+      conn.params["SAMLResponse"] -> ExSaml.SPHandler.handle_logout_response(conn)
+      conn.params["SAMLRequest"] -> ExSaml.SPHandler.handle_logout_request(conn)
+      true -> send_resp(conn, 403, "invalid_request")
+    end
+  end
+
+  # HTTP-Redirect binding (SAML 2.0 Bindings §3.4.4). Microsoft Entra ID and
+  # other IdPs deliver IdP-initiated single-logout requests as a GET with the
+  # message in the query string, signed via the SigAlg/Signature parameters.
+  get "/logout/:idp_id" do
     cond do
       conn.params["SAMLResponse"] -> ExSaml.SPHandler.handle_logout_response(conn)
       conn.params["SAMLRequest"] -> ExSaml.SPHandler.handle_logout_request(conn)

--- a/lib/ex_saml/sp_handler.ex
+++ b/lib/ex_saml/sp_handler.ex
@@ -24,6 +24,8 @@ defmodule ExSaml.SPHandler do
     Subject
   }
 
+  alias ExSaml.Core.RedirectBindingSignature
+
   import ExSaml.Helper, only: [get_idp: 1]
   import ExSaml.RouterUtil, only: [ensure_sp_uris_set: 2, send_saml_request: 5, redirect: 3]
 
@@ -228,13 +230,14 @@ defmodule ExSaml.SPHandler do
     %IdpData{sp_config: sp_cfg} = idp
     sp = ensure_sp_uris_set(sp_cfg, conn)
 
-    saml_encoding = conn.body_params["SAMLEncoding"]
     # Handle both POST and Redirect
-    saml_response = conn.body_params["SAMLResponse"] || Map.get(conn.params, "SAMLResponse")
-    rls = conn.body_params["RelayState"] || Map.get(conn.params, "RelayState")
+    saml_encoding = msg_param(conn, "SAMLEncoding")
+    saml_response = msg_param(conn, "SAMLResponse")
+    rls = msg_param(conn, "RelayState")
     relay_state = safe_decode_www_form(rls)
 
-    with {:ok, _payload} <- Helper.decode_idp_signout_resp(sp, saml_encoding, saml_response),
+    with :ok <- verify_redirect_logout_response(conn, idp),
+         {:ok, _payload} <- Helper.decode_idp_signout_resp(sp, saml_encoding, saml_response),
          ^relay_state when relay_state != nil <- get_session(conn, "relay_state"),
          ^idp_id <- get_session(conn, "idp_id"),
          target_url when target_url != nil <- get_session(conn, "target_url") do
@@ -259,36 +262,45 @@ defmodule ExSaml.SPHandler do
     %IdpData{idp_metadata: idp_meta, sp_config: sp_cfg} = idp
     sp = ensure_sp_uris_set(sp_cfg, conn)
 
-    saml_encoding = conn.body_params["SAMLEncoding"]
-    saml_request = conn.body_params["SAMLRequest"]
-    rls = conn.body_params["RelayState"]
+    # Handle both POST and Redirect
+    saml_encoding = msg_param(conn, "SAMLEncoding")
+    saml_request = msg_param(conn, "SAMLRequest")
+    rls = msg_param(conn, "RelayState")
     relay_state = safe_decode_www_form(rls)
 
-    case Helper.decode_idp_signout_req(sp, saml_encoding, saml_request) do
-      {:ok, %ExSaml.Core.LogoutRequest{name: nameid}} ->
-        assertion_key = {idp_id, nameid}
+    with {:ok, sp} <- verify_redirect_logout_request(conn, idp, sp),
+         {:ok, %ExSaml.Core.LogoutRequest{name: nameid, id: request_id}} <-
+           Helper.decode_idp_signout_req(sp, saml_encoding, saml_request) do
+      assertion_key = {idp_id, nameid}
 
-        {conn, return_status} =
-          case State.get_assertion(conn, assertion_key) do
-            %Assertion{idp_id: ^idp_id, subject: %Subject{name: ^nameid}} ->
-              conn = State.delete_assertion(conn, assertion_key)
-              {conn, :success}
+      {conn, return_status} =
+        case State.get_assertion(conn, assertion_key) do
+          %Assertion{idp_id: ^idp_id, subject: %Subject{name: ^nameid}} ->
+            conn = State.delete_assertion(conn, assertion_key)
+            {conn, :success}
 
-            _ ->
-              {conn, :denied}
-          end
+          _ ->
+            {conn, :denied}
+        end
 
-        {idp_signout_url, resp_xml_frag} =
-          Helper.gen_idp_signout_resp(sp, idp_meta, return_status)
+      {idp_signout_url, resp_xml_frag} =
+        Helper.gen_idp_signout_resp(sp, idp_meta, return_status, request_id)
 
-        conn
-        |> configure_session(drop: true)
-        |> send_saml_request(
-          idp_signout_url,
-          idp.use_redirect_for_req,
-          resp_xml_frag,
-          relay_state
-        )
+      conn
+      |> configure_session(drop: true)
+      |> send_saml_request(
+        idp_signout_url,
+        idp.use_redirect_for_req,
+        resp_xml_frag,
+        relay_state
+      )
+    else
+      # The Redirect binding signature is missing or does not verify: the
+      # request cannot be attributed to the IdP, so fail closed without
+      # touching the session and without building a LogoutResponse.
+      {:redirect_signature_error, reason} ->
+        Logger.error("[ExSaml] Logout request signature verification failed: #{inspect(reason)}")
+        conn |> send_resp(403, "invalid_request")
 
       error ->
         Logger.error("#{inspect(error)}")
@@ -309,6 +321,42 @@ defmodule ExSaml.SPHandler do
     #     conn |> send_resp(500, "request_failed")
   end
 
+  # HTTP-Redirect binding carries its signature in the query string, not in
+  # the XML (SAML 2.0 Bindings §3.4.4.1) — signed Redirect messages MUST have
+  # the XML signature removed. So for GET requests the query signature is
+  # verified against the IdP metadata certificates and, on success, the XML
+  # signature check is disabled for this request. POST (HTTP-POST binding)
+  # requests keep the XML signature check as-is.
+  defp verify_redirect_logout_request(%Plug.Conn{method: "GET"} = conn, idp, sp) do
+    if sp.idp_signs_logout_requests do
+      case RedirectBindingSignature.verify(conn.query_string, idp.certs) do
+        :ok -> {:ok, %{sp | idp_signs_logout_requests: false}}
+        {:error, reason} -> {:redirect_signature_error, reason}
+      end
+    else
+      {:ok, sp}
+    end
+  end
+
+  defp verify_redirect_logout_request(_conn, _idp, sp), do: {:ok, sp}
+
+  # LogoutResponses are verified opt-in, mirroring the XML-signature policy of
+  # `Core.Sp.validate_logout_response/2` (verify only when a signature is
+  # present): a query signature, when sent, must verify; its absence is not an
+  # error.
+  defp verify_redirect_logout_response(%Plug.Conn{method: "GET"} = conn, idp) do
+    if Map.get(conn.params, "Signature") do
+      case RedirectBindingSignature.verify(conn.query_string, idp.certs) do
+        :ok -> :ok
+        {:error, reason} -> {:redirect_signature_error, reason}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp verify_redirect_logout_response(_conn, _idp), do: :ok
+
   @doc """
   Returns the target URL from session or relay state cache, falling back
   to `target_url/0` (`Application.get_env(:ex_saml, :fallback_target_url, "/")`)
@@ -325,4 +373,14 @@ defmodule ExSaml.SPHandler do
 
   defp safe_decode_www_form(nil), do: ""
   defp safe_decode_www_form(data), do: URI.decode_www_form(data)
+
+  # Reads a SAML message parameter from the body (HTTP-POST binding) with a
+  # fallback to the query string (HTTP-Redirect binding). Body params may be
+  # unfetched when no Plug.Parsers ran (e.g. a bare GET outside Phoenix).
+  defp msg_param(conn, name) do
+    case conn.body_params do
+      %Plug.Conn.Unfetched{} -> Map.get(conn.params, name)
+      body_params -> body_params[name] || Map.get(conn.params, name)
+    end
+  end
 end

--- a/test/ex_saml/core/redirect_binding_signature_test.exs
+++ b/test/ex_saml/core/redirect_binding_signature_test.exs
@@ -1,0 +1,169 @@
+defmodule ExSaml.Core.RedirectBindingSignatureTest do
+  use ExUnit.Case, async: true
+
+  require Record
+
+  alias ExSaml.Core.RedirectBindingSignature
+
+  @rsa_sha1 "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+  @rsa_sha256 "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+
+  # Deflated+Base64 payload content is opaque to the signature scheme; any
+  # Base64-looking blob (with `+`/`/`/`=` needing URL encoding) exercises it.
+  @payload Base.encode64("<samlp:LogoutRequest ID=\"_x\"/>" <> <<0xFB, 0xEF, 0xBE>>)
+
+  defp test_key do
+    [entry] = "test/data/test.pem" |> File.read!() |> :public_key.pem_decode()
+
+    case :public_key.pem_entry_decode(entry) do
+      {:PrivateKeyInfo, _, _, key_der, _} -> :public_key.der_decode(:RSAPrivateKey, key_der)
+      key when Record.is_record(key, :RSAPrivateKey) -> key
+    end
+  end
+
+  defp test_cert_der do
+    [{:Certificate, der, :not_encrypted}] =
+      "test/data/test.crt" |> File.read!() |> :public_key.pem_decode()
+
+    der
+  end
+
+  # A syntactically valid certificate whose key does NOT match `test_key/0`,
+  # taken from the unrelated IdP metadata fixture.
+  defp other_cert_der do
+    [_, b64] =
+      Regex.run(~r/X509Certificate[^>]*>([^<]+)</, File.read!("test/data/idp_metadata.xml"))
+
+    b64 |> String.replace(~r/\s/, "") |> Base.decode64!()
+  end
+
+  # Builds a signed Redirect binding query string the way an IdP does
+  # (SAML 2.0 Bindings §3.4.4.1): URL-encode each part, concatenate in
+  # canonical order, sign, then append the URL-encoded Base64 signature.
+  defp signed_query(opts \\ []) do
+    type = Keyword.get(opts, :type, "SAMLRequest")
+    relay_state = Keyword.get(opts, :relay_state, "some relay/state+chars")
+    sig_alg = Keyword.get(opts, :sig_alg, @rsa_sha256)
+    digest = Keyword.get(opts, :digest, :sha256)
+
+    query =
+      "#{type}=#{URI.encode_www_form(@payload)}" <>
+        if(relay_state, do: "&RelayState=#{URI.encode_www_form(relay_state)}", else: "") <>
+        "&SigAlg=#{URI.encode_www_form(sig_alg)}"
+
+    signature = :public_key.sign(query, digest, test_key())
+
+    query <> "&Signature=#{URI.encode_www_form(Base.encode64(signature))}"
+  end
+
+  describe "verify/2 success cases" do
+    test "verifies an rsa-sha256 signed LogoutRequest query" do
+      assert :ok = RedirectBindingSignature.verify(signed_query(), [test_cert_der()])
+    end
+
+    test "verifies an rsa-sha1 signed query" do
+      query = signed_query(sig_alg: @rsa_sha1, digest: :sha)
+
+      assert :ok = RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "verifies a query without RelayState" do
+      query = signed_query(relay_state: nil)
+
+      assert :ok = RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "verifies a SAMLResponse payload" do
+      query = signed_query(type: "SAMLResponse")
+
+      assert :ok = RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "verifies regardless of parameter order on the wire" do
+      # Some senders put Signature/SigAlg first; the signed data must still be
+      # rebuilt in canonical order from the raw values.
+      parts = String.split(signed_query(), "&")
+      reordered = parts |> Enum.reverse() |> Enum.join("&")
+
+      assert :ok = RedirectBindingSignature.verify(reordered, [test_cert_der()])
+    end
+
+    test "succeeds when any one of multiple certificates matches (rotation)" do
+      certs = [other_cert_der(), test_cert_der()]
+
+      assert :ok = RedirectBindingSignature.verify(signed_query(), certs)
+    end
+
+    test "skips undecodable certificates and still verifies with a later one" do
+      certs = ["not a certificate", test_cert_der()]
+
+      assert :ok = RedirectBindingSignature.verify(signed_query(), certs)
+    end
+  end
+
+  describe "verify/2 rejection cases" do
+    test "rejects a tampered payload" do
+      query =
+        String.replace(
+          signed_query(),
+          "SAMLRequest=",
+          "SAMLRequest=#{URI.encode_www_form(Base.encode64("forged"))}"
+        )
+
+      assert {:error, :invalid_signature} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "rejects a tampered RelayState" do
+      query = String.replace(signed_query(), "RelayState=some", "RelayState=evil")
+
+      assert {:error, :invalid_signature} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "rejects when the signing key matches none of the certificates" do
+      assert {:error, :invalid_signature} =
+               RedirectBindingSignature.verify(signed_query(), [other_cert_der()])
+    end
+
+    test "rejects when the certificate list is empty" do
+      assert {:error, :invalid_signature} = RedirectBindingSignature.verify(signed_query(), [])
+    end
+
+    test "rejects a malformed Base64 signature" do
+      query = Regex.replace(~r/Signature=.*$/, signed_query(), "Signature=%25%25not-base64")
+
+      assert {:error, :invalid_signature} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "rejects when the Signature parameter is missing" do
+      query = Regex.replace(~r/&Signature=.*$/, signed_query(), "")
+
+      assert {:error, :missing_signature} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "rejects when the SigAlg parameter is missing" do
+      query = String.replace(signed_query(), ~r/&SigAlg=[^&]*/, "")
+
+      assert {:error, :missing_signature} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "rejects when no SAMLRequest/SAMLResponse payload is present" do
+      query = String.replace(signed_query(), ~r/^SAMLRequest=[^&]*&/, "")
+
+      assert {:error, :missing_signature} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+
+    test "rejects an unsupported SigAlg URI" do
+      unsupported = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256"
+      query = signed_query(sig_alg: unsupported)
+
+      assert {:error, :unsupported_sig_alg} =
+               RedirectBindingSignature.verify(query, [test_cert_der()])
+    end
+  end
+end

--- a/test/ex_saml/core/sp_test.exs
+++ b/test/ex_saml/core/sp_test.exs
@@ -319,5 +319,21 @@ defmodule ExSaml.Core.SpTest do
       status = find_child(xml, :"samlp:Status")
       assert status != nil
     end
+
+    test "emits InResponseTo when the answered request ID is given" do
+      sp = base_sp()
+
+      xml = Sp.generate_logout_response("https://idp.example.com/slo", :success, sp, "_req_1")
+
+      assert attr_to_string(find_attr(xml, :InResponseTo)) == "_req_1"
+    end
+
+    test "omits InResponseTo when the request ID is empty" do
+      sp = base_sp()
+
+      xml = Sp.generate_logout_response("https://idp.example.com/slo", :success, sp)
+
+      assert find_attr(xml, :InResponseTo) == nil
+    end
   end
 end

--- a/test/ex_saml/sp_logout_redirect_binding_test.exs
+++ b/test/ex_saml/sp_logout_redirect_binding_test.exs
@@ -1,0 +1,265 @@
+defmodule ExSaml.SPLogoutRedirectBindingTest do
+  @moduledoc """
+  End-to-end tests for single logout over the HTTP-Redirect binding
+  (SAML 2.0 Bindings §3.4.4), routed through `ExSaml.SPRouter`:
+
+  IdP-initiated `GET /logout/:idp_id` requests carry the LogoutRequest in the
+  query string, signed via the SigAlg/Signature query parameters (the way
+  Microsoft Entra ID delivers them). The HTTP-POST binding route must keep its
+  existing behaviour.
+  """
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+  import Plug.Conn, only: [get_resp_header: 2]
+
+  require Record
+
+  alias ExSaml.{Assertion, IdpData, State, Subject}
+  alias ExSaml.Core.{IdpMetadata, SpConfig}
+
+  @idp_id "idp1"
+  @nameid "user@example.com"
+  @request_id "_logout_req_42"
+  @logout_location "https://idp.example.com/slo"
+  @rsa_sha256 "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+  @success_status "urn:oasis:names:tc:SAML:2.0:status:Success"
+  @denied_status "urn:oasis:names:tc:SAML:2.0:status:RequestDenied"
+
+  setup do
+    previous_idps = Application.get_env(:ex_saml, :identity_providers)
+    previous_store = Application.get_env(:ex_saml, :state_store)
+
+    State.init(ExSaml.State.ETS, table: :slo_redirect_binding_test)
+    :ets.delete_all_objects(:slo_redirect_binding_test)
+
+    Application.put_env(:ex_saml, :identity_providers, %{@idp_id => idp_data()})
+
+    on_exit(fn ->
+      if previous_idps do
+        Application.put_env(:ex_saml, :identity_providers, previous_idps)
+      else
+        Application.delete_env(:ex_saml, :identity_providers)
+      end
+
+      if previous_store do
+        Application.put_env(:ex_saml, :state_store, previous_store)
+      else
+        Application.delete_env(:ex_saml, :state_store)
+      end
+    end)
+
+    :ok
+  end
+
+  # ---------------------------------------------------------------------------
+  # Fixtures
+  # ---------------------------------------------------------------------------
+
+  defp idp_data(sp_overrides \\ []) do
+    sp_config =
+      struct!(
+        %SpConfig{
+          entity_id: ~c"https://sp.example.com",
+          metadata_uri: "https://sp.example.com/sp/metadata/#{@idp_id}",
+          consume_uri: "https://sp.example.com/sp/consume/#{@idp_id}",
+          logout_uri: "https://sp.example.com/sp/logout/#{@idp_id}",
+          sp_sign_requests: false,
+          sp_sign_metadata: false
+        },
+        sp_overrides
+      )
+
+    %IdpData{
+      id: @idp_id,
+      certs: [test_cert_der()],
+      use_redirect_for_req: true,
+      sp_config: sp_config,
+      idp_metadata: %IdpMetadata{
+        entity_id: "https://idp.example.com",
+        login_location: "https://idp.example.com/sso",
+        logout_location: @logout_location
+      }
+    }
+  end
+
+  defp test_key do
+    [entry] = "test/data/test.pem" |> File.read!() |> :public_key.pem_decode()
+
+    case :public_key.pem_entry_decode(entry) do
+      {:PrivateKeyInfo, _, _, key_der, _} -> :public_key.der_decode(:RSAPrivateKey, key_der)
+      key when Record.is_record(key, :RSAPrivateKey) -> key
+    end
+  end
+
+  defp test_cert_der do
+    [{:Certificate, der, :not_encrypted}] =
+      "test/data/test.crt" |> File.read!() |> :public_key.pem_decode()
+
+    der
+  end
+
+  defp logout_request_payload do
+    xml =
+      ~s(<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ) <>
+        ~s(xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="#{@request_id}" ) <>
+        ~s(Version="2.0" IssueInstant="#{DateTime.to_iso8601(DateTime.utc_now())}">) <>
+        ~s(<saml:Issuer>https://idp.example.com</saml:Issuer>) <>
+        ~s(<saml:NameID>#{@nameid}</saml:NameID>) <>
+        ~s(</samlp:LogoutRequest>)
+
+    xml |> :zlib.zip() |> Base.encode64()
+  end
+
+  # Builds the signed query string the way an IdP does (§3.4.4.1): URL-encode
+  # each part, concatenate in canonical order, sign, append the signature.
+  defp signed_logout_query(opts \\ []) do
+    relay_state = Keyword.get(opts, :relay_state, "entra_relay")
+
+    query =
+      "SAMLRequest=#{URI.encode_www_form(logout_request_payload())}" <>
+        if(relay_state, do: "&RelayState=#{URI.encode_www_form(relay_state)}", else: "") <>
+        "&SigAlg=#{URI.encode_www_form(@rsa_sha256)}"
+
+    signature = :public_key.sign(query, :sha256, test_key())
+    signed = query <> "&Signature=#{URI.encode_www_form(Base.encode64(signature))}"
+
+    if Keyword.get(opts, :tamper, false) do
+      String.replace(signed, "SAMLRequest=", "SAMLRequest=eJxLy0lMBwAD", global: false)
+    else
+      signed
+    end
+  end
+
+  defp unsigned_logout_query do
+    "SAMLRequest=#{URI.encode_www_form(logout_request_payload())}&RelayState=entra_relay"
+  end
+
+  defp put_active_assertion do
+    notonorafter = DateTime.utc_now() |> DateTime.add(300) |> DateTime.to_iso8601()
+
+    assertion = %Assertion{
+      idp_id: @idp_id,
+      subject: %Subject{name: @nameid, notonorafter: notonorafter}
+    }
+
+    State.put_assertion(conn(:get, "/"), {@idp_id, @nameid}, assertion)
+  end
+
+  defp active_assertion, do: State.get_assertion(conn(:get, "/"), {@idp_id, @nameid})
+
+  defp call_get_logout(query) do
+    :get
+    |> conn("/logout/#{@idp_id}?#{query}")
+    |> init_test_session(%{})
+    |> ExSaml.SPRouter.call(ExSaml.SPRouter.init([]))
+  end
+
+  defp logout_response_from(conn) do
+    assert conn.status == 302
+    [location] = get_resp_header(conn, "location")
+    assert String.starts_with?(location, @logout_location)
+
+    query = location |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+    xml = query["SAMLResponse"] |> Base.decode64!() |> :zlib.unzip()
+    {xml, query}
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET (HTTP-Redirect binding)
+  # ---------------------------------------------------------------------------
+
+  describe "GET /logout/:idp_id with a signed LogoutRequest" do
+    test "destroys the assertion and answers Success with InResponseTo" do
+      put_active_assertion()
+
+      conn = call_get_logout(signed_logout_query())
+
+      {xml, query} = logout_response_from(conn)
+      assert xml =~ @success_status
+      assert xml =~ ~s(InResponseTo="#{@request_id}")
+      assert query["RelayState"] == "entra_relay"
+      assert active_assertion() == nil
+    end
+
+    test "answers RequestDenied when no assertion is active" do
+      conn = call_get_logout(signed_logout_query())
+
+      {xml, _query} = logout_response_from(conn)
+      assert xml =~ @denied_status
+      assert xml =~ ~s(InResponseTo="#{@request_id}")
+    end
+
+    test "works without RelayState" do
+      put_active_assertion()
+
+      conn = call_get_logout(signed_logout_query(relay_state: nil))
+
+      {xml, _query} = logout_response_from(conn)
+      assert xml =~ @success_status
+    end
+  end
+
+  describe "GET /logout/:idp_id signature rejection" do
+    test "rejects an unsigned LogoutRequest and keeps the assertion" do
+      put_active_assertion()
+
+      conn = call_get_logout(unsigned_logout_query())
+
+      assert conn.status == 403
+      assert conn.resp_body == "invalid_request"
+      assert %Assertion{} = active_assertion()
+    end
+
+    test "rejects a tampered LogoutRequest and keeps the assertion" do
+      put_active_assertion()
+
+      conn = call_get_logout(signed_logout_query(tamper: true))
+
+      assert conn.status == 403
+      assert %Assertion{} = active_assertion()
+    end
+
+    test "accepts an unsigned LogoutRequest when idp_signs_logout_requests is disabled" do
+      Application.put_env(:ex_saml, :identity_providers, %{
+        @idp_id => idp_data(idp_signs_logout_requests: false)
+      })
+
+      put_active_assertion()
+
+      conn = call_get_logout(unsigned_logout_query())
+
+      {xml, _query} = logout_response_from(conn)
+      assert xml =~ @success_status
+      assert active_assertion() == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST (HTTP-POST binding) - existing behaviour must be unchanged
+  # ---------------------------------------------------------------------------
+
+  describe "POST /logout/:idp_id" do
+    test "still processes a LogoutRequest from body params" do
+      Application.put_env(:ex_saml, :identity_providers, %{
+        @idp_id => idp_data(idp_signs_logout_requests: false)
+      })
+
+      put_active_assertion()
+
+      conn =
+        :post
+        |> conn("/logout/#{@idp_id}", %{
+          "SAMLRequest" => logout_request_payload(),
+          "RelayState" => "post_relay"
+        })
+        |> init_test_session(%{})
+        |> ExSaml.SPRouter.call(ExSaml.SPRouter.init([]))
+
+      {xml, query} = logout_response_from(conn)
+      assert xml =~ @success_status
+      assert query["RelayState"] == "post_relay"
+      assert active_assertion() == nil
+    end
+  end
+end


### PR DESCRIPTION
Microsoft Entra ID (and other IdPs) deliver IdP-initiated single-logout LogoutRequests over the HTTP-Redirect binding: a GET with the message in the query string, signed via the SigAlg/Signature query parameters (SAML 2.0 Bindings §3.4.4.1). ExSaml only accepted SLO messages over HTTP-POST, so such requests were rejected with 403.

- Add GET /logout/:idp_id to ExSaml.SPRouter (POST route unchanged) and fetch query params in the router (Plug.Router does not on its own).
- Add ExSaml.Core.RedirectBindingSignature, which rebuilds the signed data from the raw (still URL-encoded) query values in canonical order and verifies it against the IdP metadata DER certificates, accepting any one match (certificate rotation). Modelled after ruby-saml's Utils.verify_signature / build_query_from_raw_parts.
- In SPHandler.handle_logout_request, require and verify the query signature for GET requests when idp_signs_logout_requests is set, failing closed (403, session untouched) on missing/invalid signatures. The XML signature check is skipped for verified Redirect messages (the binding mandates the XML signature be removed). POST keeps the existing XML signature verification.
- In SPHandler.handle_logout_response, verify the query signature opt-in (only when a Signature parameter is present), mirroring the existing XML-signature policy for LogoutResponses.
- Decode the LogoutRequest ID and answer with InResponseTo on the generated LogoutResponse (SAML 2.0 Core §3.7.3.2).