### PR TITLE
🩺 Log rejected SAML auth responses with error reason and relay-state context

### DIFF
--- a/lib/ex_saml/sp_handler.ex
+++ b/lib/ex_saml/sp_handler.ex
@@ -99,6 +99,13 @@ defmodule ExSaml.SPHandler do
         conn
 
       {:error, error} ->
+        Logger.warning(
+          "[ExSaml] SAML auth response rejected: #{inspect(error)} " <>
+            "(idp_id=#{inspect(idp_id)}, " <>
+            "relay_state_present?=#{relay_state not in [nil, ""]}, " <>
+            "relay_state_cached?=#{RelayStateCache.get(relay_state) != nil})"
+        )
+
         redirect_with_error(conn, relay_state, error)
 
       # Defensive fallback: unreachable today (Dialyzer flags it as such), but


### PR DESCRIPTION
Adds a `Logger.warning` at the single choke point where `consume_signin_response/1` rejects an IdP auth response, so failures surface the concrete reason (`:invalid_relay_state`, signature/decode errors, `:invalid_idp_id`, …) instead of being swallowed into a session that is dropped on the cross-site ACS POST.

Logs the error, `idp_id`, whether the IdP echoed a `RelayState`, and whether it was still in the cache — enough to tell apart a dropped/mangled RelayState from a decode/validation failure.